### PR TITLE
Updated for EF Core 3.0

### DIFF
--- a/src/MockQueryable/MockQueryable.FakeItEasy/FakeItEasyExtensions.cs
+++ b/src/MockQueryable/MockQueryable.FakeItEasy/FakeItEasyExtensions.cs
@@ -13,11 +13,9 @@ namespace MockQueryable.FakeItEasy
         {
             var mock = A.Fake<IQueryable<TEntity>>(d=>d.Implements<IAsyncEnumerable<TEntity>>().Implements<IQueryable<TEntity>>());
             var enumerable = new TestAsyncEnumerable<TEntity>(data);
-            A.CallTo(() => ((IAsyncEnumerable<TEntity>) mock).GetAsyncEnumerator(A<CancellationToken>.Ignored)).Returns(enumerable.GetAsyncEnumerator());
-            A.CallTo(() => ((IQueryable<TEntity>)mock).Provider).Returns(enumerable);
-            A.CallTo(() => ((IQueryable<TEntity>)mock).Expression).Returns(data?.Expression);
-            A.CallTo(() => ((IQueryable<TEntity>)mock).ElementType).Returns(data?.ElementType);
-            A.CallTo(() => ((IQueryable<TEntity>)mock).GetEnumerator()).Returns(data?.GetEnumerator());
+            ((IAsyncEnumerable<TEntity>)mock).ConfigureAsyncEnumerableCalls(enumerable);
+            mock.ConfigureQueryableCalls(enumerable, data);
+
             return mock;
         }
 
@@ -25,11 +23,8 @@ namespace MockQueryable.FakeItEasy
         {
             var mock = A.Fake<DbSet<TEntity>>(d => d.Implements<IAsyncEnumerable<TEntity>>().Implements<IQueryable<TEntity>>());
             var enumerable = new TestAsyncEnumerable<TEntity>(data);
-            A.CallTo(() => ((IAsyncEnumerable<TEntity>)mock).GetAsyncEnumerator(A<CancellationToken>.Ignored)).Returns(enumerable.GetAsyncEnumerator());
-            A.CallTo(() => ((IQueryable<TEntity>)mock).Provider).Returns(enumerable);
-            A.CallTo(() => ((IQueryable<TEntity>)mock).Expression).Returns(data?.Expression);
-            A.CallTo(() => ((IQueryable<TEntity>)mock).ElementType).Returns(data?.ElementType);
-            A.CallTo(() => ((IQueryable<TEntity>)mock).GetEnumerator()).Returns(data?.GetEnumerator());
+            mock.ConfigureQueryableCalls(enumerable, data);
+            mock.ConfigureAsyncEnumerableCalls(enumerable);
             return mock;
         }
 
@@ -38,12 +33,25 @@ namespace MockQueryable.FakeItEasy
         {
             var mock = A.Fake<DbQuery<TEntity>>(d => d.Implements<IAsyncEnumerable<TEntity>>().Implements<IQueryable<TEntity>>());
             var enumerable = new TestAsyncEnumerable<TEntity>(data);
-            A.CallTo(() => ((IAsyncEnumerable<TEntity>)mock).GetAsyncEnumerator(A<CancellationToken>.Ignored)).Returns(enumerable.GetAsyncEnumerator());
-            A.CallTo(() => ((IQueryable<TEntity>)mock).Provider).Returns(enumerable);
-            A.CallTo(() => ((IQueryable<TEntity>)mock).Expression).Returns(data?.Expression);
-            A.CallTo(() => ((IQueryable<TEntity>)mock).ElementType).Returns(data?.ElementType);
-            A.CallTo(() => ((IQueryable<TEntity>)mock).GetEnumerator()).Returns(data?.GetEnumerator());
+            mock.ConfigureQueryableCalls(enumerable, data);
+            mock.ConfigureAsyncEnumerableCalls(enumerable);
             return mock;
+        }
+
+        private static void ConfigureQueryableCalls<TEntity>(this IQueryable<TEntity> mock, IQueryProvider queryProvider, IQueryable<TEntity> data)
+            where TEntity : class
+        {
+            A.CallTo(() => mock.Provider).Returns(queryProvider);
+            A.CallTo(() => mock.Expression).Returns(data?.Expression);
+            A.CallTo(() => mock.ElementType).Returns(data?.ElementType);
+            A.CallTo(() => mock.GetEnumerator()).Returns(data?.GetEnumerator());
+        }
+
+        private static void ConfigureAsyncEnumerableCalls<TEntity>(
+            this IAsyncEnumerable<TEntity> mock,
+            IAsyncEnumerable<TEntity> enumerable)
+        {
+            A.CallTo(() => mock.GetAsyncEnumerator(A<CancellationToken>.Ignored)).Returns(enumerable.GetAsyncEnumerator());
         }
     }
 }

--- a/src/MockQueryable/MockQueryable.FakeItEasy/FakeItEasyExtensions.cs
+++ b/src/MockQueryable/MockQueryable.FakeItEasy/FakeItEasyExtensions.cs
@@ -7,51 +7,57 @@ using Microsoft.EntityFrameworkCore;
 
 namespace MockQueryable.FakeItEasy
 {
-    public static class FakeItEasyExtensions
-    {
-        public static IQueryable<TEntity> BuildMock<TEntity>(this IQueryable<TEntity> data) where TEntity : class
-        {
-            var mock = A.Fake<IQueryable<TEntity>>(d=>d.Implements<IAsyncEnumerable<TEntity>>().Implements<IQueryable<TEntity>>());
-            var enumerable = new TestAsyncEnumerable<TEntity>(data);
-            ((IAsyncEnumerable<TEntity>)mock).ConfigureAsyncEnumerableCalls(enumerable);
-            mock.ConfigureQueryableCalls(enumerable, data);
+	public static class FakeItEasyExtensions
+	{
+		public static IQueryable<TEntity> BuildMock<TEntity>(this IQueryable<TEntity> data) where TEntity : class
+		{
+			var mock = A.Fake<IQueryable<TEntity>>(
+				d => d.Implements<IAsyncEnumerable<TEntity>>().Implements<IQueryable<TEntity>>());
+			var enumerable = new TestAsyncEnumerable<TEntity>(data);
+			((IAsyncEnumerable<TEntity>) mock).ConfigureAsyncEnumerableCalls(enumerable);
+			mock.ConfigureQueryableCalls(enumerable, data);
 
-            return mock;
-        }
+			return mock;
+		}
 
-        public static DbSet<TEntity> BuildMockDbSet<TEntity>(this IQueryable<TEntity> data) where TEntity : class
-        {
-            var mock = A.Fake<DbSet<TEntity>>(d => d.Implements<IAsyncEnumerable<TEntity>>().Implements<IQueryable<TEntity>>());
-            var enumerable = new TestAsyncEnumerable<TEntity>(data);
-            mock.ConfigureQueryableCalls(enumerable, data);
-            mock.ConfigureAsyncEnumerableCalls(enumerable);
-            return mock;
-        }
+		public static DbSet<TEntity> BuildMockDbSet<TEntity>(this IQueryable<TEntity> data) where TEntity : class
+		{
+			var mock = A.Fake<DbSet<TEntity>>(
+				d => d.Implements<IAsyncEnumerable<TEntity>>().Implements<IQueryable<TEntity>>());
+			var enumerable = new TestAsyncEnumerable<TEntity>(data);
+			mock.ConfigureQueryableCalls(enumerable, data);
+			mock.ConfigureAsyncEnumerableCalls(enumerable);
+			return mock;
+		}
 
-        [Obsolete]
-        public static DbQuery<TEntity> BuildMockDbQuery<TEntity>(this IQueryable<TEntity> data) where TEntity : class
-        {
-            var mock = A.Fake<DbQuery<TEntity>>(d => d.Implements<IAsyncEnumerable<TEntity>>().Implements<IQueryable<TEntity>>());
-            var enumerable = new TestAsyncEnumerable<TEntity>(data);
-            mock.ConfigureQueryableCalls(enumerable, data);
-            mock.ConfigureAsyncEnumerableCalls(enumerable);
-            return mock;
-        }
+		[Obsolete]
+		public static DbQuery<TEntity> BuildMockDbQuery<TEntity>(this IQueryable<TEntity> data) where TEntity : class
+		{
+			var mock = A.Fake<DbQuery<TEntity>>(
+				d => d.Implements<IAsyncEnumerable<TEntity>>().Implements<IQueryable<TEntity>>());
+			var enumerable = new TestAsyncEnumerable<TEntity>(data);
+			mock.ConfigureQueryableCalls(enumerable, data);
+			mock.ConfigureAsyncEnumerableCalls(enumerable);
+			return mock;
+		}
 
-        private static void ConfigureQueryableCalls<TEntity>(this IQueryable<TEntity> mock, IQueryProvider queryProvider, IQueryable<TEntity> data)
-            where TEntity : class
-        {
-            A.CallTo(() => mock.Provider).Returns(queryProvider);
-            A.CallTo(() => mock.Expression).Returns(data?.Expression);
-            A.CallTo(() => mock.ElementType).Returns(data?.ElementType);
-            A.CallTo(() => mock.GetEnumerator()).Returns(data?.GetEnumerator());
-        }
+		private static void ConfigureQueryableCalls<TEntity>(
+			this IQueryable<TEntity> mock,
+			IQueryProvider queryProvider,
+			IQueryable<TEntity> data) where TEntity : class
+		{
+			A.CallTo(() => mock.Provider).Returns(queryProvider);
+			A.CallTo(() => mock.Expression).Returns(data?.Expression);
+			A.CallTo(() => mock.ElementType).Returns(data?.ElementType);
+			A.CallTo(() => mock.GetEnumerator()).Returns(data?.GetEnumerator());
+		}
 
-        private static void ConfigureAsyncEnumerableCalls<TEntity>(
-            this IAsyncEnumerable<TEntity> mock,
-            IAsyncEnumerable<TEntity> enumerable)
-        {
-            A.CallTo(() => mock.GetAsyncEnumerator(A<CancellationToken>.Ignored)).Returns(enumerable.GetAsyncEnumerator());
-        }
-    }
+		private static void ConfigureAsyncEnumerableCalls<TEntity>(
+			this IAsyncEnumerable<TEntity> mock,
+			IAsyncEnumerable<TEntity> enumerable)
+		{
+			A.CallTo(() => mock.GetAsyncEnumerator(A<CancellationToken>.Ignored))
+				.Returns(enumerable.GetAsyncEnumerator());
+		}
+	}
 }

--- a/src/MockQueryable/MockQueryable.FakeItEasy/FakeItEasyExtensions.cs
+++ b/src/MockQueryable/MockQueryable.FakeItEasy/FakeItEasyExtensions.cs
@@ -1,5 +1,7 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using FakeItEasy;
 using Microsoft.EntityFrameworkCore;
 
@@ -11,7 +13,7 @@ namespace MockQueryable.FakeItEasy
         {
             var mock = A.Fake<IQueryable<TEntity>>(d=>d.Implements<IAsyncEnumerable<TEntity>>().Implements<IQueryable<TEntity>>());
             var enumerable = new TestAsyncEnumerable<TEntity>(data);
-            A.CallTo(() => ((IAsyncEnumerable<TEntity>) mock).GetEnumerator()).Returns(enumerable.GetEnumerator());
+            A.CallTo(() => ((IAsyncEnumerable<TEntity>) mock).GetAsyncEnumerator(A<CancellationToken>.Ignored)).Returns(enumerable.GetAsyncEnumerator());
             A.CallTo(() => ((IQueryable<TEntity>)mock).Provider).Returns(enumerable);
             A.CallTo(() => ((IQueryable<TEntity>)mock).Expression).Returns(data?.Expression);
             A.CallTo(() => ((IQueryable<TEntity>)mock).ElementType).Returns(data?.ElementType);
@@ -23,7 +25,7 @@ namespace MockQueryable.FakeItEasy
         {
             var mock = A.Fake<DbSet<TEntity>>(d => d.Implements<IAsyncEnumerable<TEntity>>().Implements<IQueryable<TEntity>>());
             var enumerable = new TestAsyncEnumerable<TEntity>(data);
-            A.CallTo(() => ((IAsyncEnumerable<TEntity>)mock).GetEnumerator()).Returns(enumerable.GetEnumerator());
+            A.CallTo(() => ((IAsyncEnumerable<TEntity>)mock).GetAsyncEnumerator(A<CancellationToken>.Ignored)).Returns(enumerable.GetAsyncEnumerator());
             A.CallTo(() => ((IQueryable<TEntity>)mock).Provider).Returns(enumerable);
             A.CallTo(() => ((IQueryable<TEntity>)mock).Expression).Returns(data?.Expression);
             A.CallTo(() => ((IQueryable<TEntity>)mock).ElementType).Returns(data?.ElementType);
@@ -31,11 +33,12 @@ namespace MockQueryable.FakeItEasy
             return mock;
         }
 
+        [Obsolete]
         public static DbQuery<TEntity> BuildMockDbQuery<TEntity>(this IQueryable<TEntity> data) where TEntity : class
         {
             var mock = A.Fake<DbQuery<TEntity>>(d => d.Implements<IAsyncEnumerable<TEntity>>().Implements<IQueryable<TEntity>>());
             var enumerable = new TestAsyncEnumerable<TEntity>(data);
-            A.CallTo(() => ((IAsyncEnumerable<TEntity>)mock).GetEnumerator()).Returns(enumerable.GetEnumerator());
+            A.CallTo(() => ((IAsyncEnumerable<TEntity>)mock).GetAsyncEnumerator(A<CancellationToken>.Ignored)).Returns(enumerable.GetAsyncEnumerator());
             A.CallTo(() => ((IQueryable<TEntity>)mock).Provider).Returns(enumerable);
             A.CallTo(() => ((IQueryable<TEntity>)mock).Expression).Returns(data?.Expression);
             A.CallTo(() => ((IQueryable<TEntity>)mock).ElementType).Returns(data?.ElementType);

--- a/src/MockQueryable/MockQueryable.FakeItEasy/MockQueryable.FakeItEasy.csproj
+++ b/src/MockQueryable/MockQueryable.FakeItEasy/MockQueryable.FakeItEasy.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <PackageId>MockQueryable.FakeItEasy</PackageId>
     <Authors>Roman Titov</Authors>
     <Description>Async operations with generic collections, to provide for collections such List&lt;T&gt; execute EntityFrameworkCore operations such ToListAsync, FirstOrDefaultAsync etc.</Description>
@@ -11,9 +11,9 @@
     <PackageProjectUrl>https://github.com/romantitov/MockQueryable</PackageProjectUrl>
     <RepositoryUrl>https://github.com/romantitov/MockQueryable</RepositoryUrl>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>1.1.0</Version>
-    <AssemblyVersion>1.1.0.0</AssemblyVersion>
-    <FileVersion>1.1.0.0</FileVersion>
+    <Version>1.2.0-alpha</Version>
+    <AssemblyVersion>1.2.0.0</AssemblyVersion>
+    <FileVersion>1.2.0.0</FileVersion>
     <Company></Company>
   </PropertyGroup>
 

--- a/src/MockQueryable/MockQueryable.Moq/MockQueryable.Moq.csproj
+++ b/src/MockQueryable/MockQueryable.Moq/MockQueryable.Moq.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <Authors>Roman Titov</Authors>
     <Company></Company>
-	<Version>1.1.0</Version>
+	<Version>1.2.0-alpha</Version>
     <Description>Extension for mocking Entity Framework Core operations such ToListAsync, FirstOrDefaultAsync etc. by Moq
 When writing tests for your application it is often desirable to avoid hitting the database. The extension allows you to achieve this by creating a context – with behavior defined by your tests – that makes use of in-memory data.</Description>
     <PackageProjectUrl>https://github.com/romantitov/MockQueryable</PackageProjectUrl>
@@ -12,8 +12,8 @@ When writing tests for your application it is often desirable to avoid hitting t
     <PackageTags>Moq EntityFrameworkCore Queryable mock EF UnitTests</PackageTags>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>MockQueryable.Moq</PackageId>
-    <AssemblyVersion>1.1.0.0</AssemblyVersion>
-    <FileVersion>1.1.0.0</FileVersion>
+    <AssemblyVersion>1.2.0.0</AssemblyVersion>
+    <FileVersion>1.2.0.0</FileVersion>
     <PackageReleaseNotes>AutoMapper support</PackageReleaseNotes>
   </PropertyGroup>
 

--- a/src/MockQueryable/MockQueryable.Moq/MoqExtensions.cs
+++ b/src/MockQueryable/MockQueryable.Moq/MoqExtensions.cs
@@ -13,23 +13,17 @@ namespace MockQueryable.Moq
 		{
 			var mock = new Mock<IQueryable<TEntity>>();
 			var enumerable = new TestAsyncEnumerable<TEntity>(data);
-			mock.As<IAsyncEnumerable<TEntity>>().Setup(d => d.GetAsyncEnumerator(It.IsAny<CancellationToken>())).Returns(() => enumerable.GetAsyncEnumerator());
-			mock.As<IQueryable<TEntity>>().Setup(m => m.Provider).Returns(enumerable);
-			mock.As<IQueryable<TEntity>>().Setup(m => m.Expression).Returns(data?.Expression);
-			mock.As<IQueryable<TEntity>>().Setup(m => m.ElementType).Returns(data?.ElementType);
-			mock.As<IQueryable<TEntity>>().Setup(m => m.GetEnumerator()).Returns(data?.GetEnumerator());
-			return mock;
+            mock.As<IAsyncEnumerable<TEntity>>().ConfigureAsyncEnumerableCalls(enumerable);
+            mock.ConfigureQueryableCalls(enumerable, data);
+            return mock;
 		}
 
 	    public static Mock<DbSet<TEntity>> BuildMockDbSet<TEntity>(this IQueryable<TEntity> data) where TEntity : class
 	    {
 	        var mock = new Mock<DbSet<TEntity>>();
 	        var enumerable = new TestAsyncEnumerable<TEntity>(data);
-	        mock.As<IAsyncEnumerable<TEntity>>().Setup(d => d.GetAsyncEnumerator(It.IsAny<CancellationToken>())).Returns(() => enumerable.GetAsyncEnumerator());
-	        mock.As<IQueryable<TEntity>>().Setup(m => m.Provider).Returns(enumerable);
-	        mock.As<IQueryable<TEntity>>().Setup(m => m.Expression).Returns(data?.Expression);
-	        mock.As<IQueryable<TEntity>>().Setup(m => m.ElementType).Returns(data?.ElementType);
-	        mock.As<IQueryable<TEntity>>().Setup(m => m.GetEnumerator()).Returns(data?.GetEnumerator());
+            mock.As<IAsyncEnumerable<TEntity>>().ConfigureAsyncEnumerableCalls(enumerable);
+            mock.As<IQueryable<TEntity>>().ConfigureQueryableCalls(enumerable, data);
 	        return mock;
         }
 
@@ -38,12 +32,25 @@ namespace MockQueryable.Moq
 	    {
 	        var mock = new Mock<DbQuery<TEntity>>();
 	        var enumerable = new TestAsyncEnumerable<TEntity>(data);
-            mock.As<IAsyncEnumerable<TEntity>>().Setup(d => d.GetAsyncEnumerator(It.IsAny<CancellationToken>())).Returns(() => enumerable.GetAsyncEnumerator());
-            mock.As<IQueryable<TEntity>>().Setup(m => m.Provider).Returns(enumerable);
-	        mock.As<IQueryable<TEntity>>().Setup(m => m.Expression).Returns(data?.Expression);
-	        mock.As<IQueryable<TEntity>>().Setup(m => m.ElementType).Returns(data?.ElementType);
-	        mock.As<IQueryable<TEntity>>().Setup(m => m.GetEnumerator()).Returns(data?.GetEnumerator());
-	        return mock;
+            mock.As<IAsyncEnumerable<TEntity>>().ConfigureAsyncEnumerableCalls(enumerable);
+            mock.As<IQueryable<TEntity>>().ConfigureQueryableCalls(enumerable, data);
+            return mock;
+        }
+
+        private static void ConfigureQueryableCalls<TEntity>(this Mock<IQueryable<TEntity>> mock, IQueryProvider queryProvider, IQueryable<TEntity> data)
+            where TEntity : class
+        {
+            mock.Setup(m => m.Provider).Returns(queryProvider);
+            mock.Setup(m => m.Expression).Returns(data?.Expression);
+            mock.Setup(m => m.ElementType).Returns(data?.ElementType);
+            mock.Setup(m => m.GetEnumerator()).Returns(data?.GetEnumerator());
+        }
+
+        private static void ConfigureAsyncEnumerableCalls<TEntity>(
+            this Mock<IAsyncEnumerable<TEntity>> mock,
+            IAsyncEnumerable<TEntity> enumerable)
+        {
+            mock.Setup(d => d.GetAsyncEnumerator(It.IsAny<CancellationToken>())).Returns(() => enumerable.GetAsyncEnumerator());
         }
     }
 }

--- a/src/MockQueryable/MockQueryable.Moq/MoqExtensions.cs
+++ b/src/MockQueryable/MockQueryable.Moq/MoqExtensions.cs
@@ -13,44 +13,48 @@ namespace MockQueryable.Moq
 		{
 			var mock = new Mock<IQueryable<TEntity>>();
 			var enumerable = new TestAsyncEnumerable<TEntity>(data);
-            mock.As<IAsyncEnumerable<TEntity>>().ConfigureAsyncEnumerableCalls(enumerable);
-            mock.ConfigureQueryableCalls(enumerable, data);
-            return mock;
+			mock.As<IAsyncEnumerable<TEntity>>().ConfigureAsyncEnumerableCalls(enumerable);
+			mock.ConfigureQueryableCalls(enumerable, data);
+			return mock;
 		}
 
-	    public static Mock<DbSet<TEntity>> BuildMockDbSet<TEntity>(this IQueryable<TEntity> data) where TEntity : class
-	    {
-	        var mock = new Mock<DbSet<TEntity>>();
-	        var enumerable = new TestAsyncEnumerable<TEntity>(data);
-            mock.As<IAsyncEnumerable<TEntity>>().ConfigureAsyncEnumerableCalls(enumerable);
-            mock.As<IQueryable<TEntity>>().ConfigureQueryableCalls(enumerable, data);
-	        return mock;
-        }
+		public static Mock<DbSet<TEntity>> BuildMockDbSet<TEntity>(this IQueryable<TEntity> data) where TEntity : class
+		{
+			var mock = new Mock<DbSet<TEntity>>();
+			var enumerable = new TestAsyncEnumerable<TEntity>(data);
+			mock.As<IAsyncEnumerable<TEntity>>().ConfigureAsyncEnumerableCalls(enumerable);
+			mock.As<IQueryable<TEntity>>().ConfigureQueryableCalls(enumerable, data);
+			return mock;
+		}
 
-        [Obsolete]
-        public static Mock<DbQuery<TEntity>> BuildMockDbQuery<TEntity>(this IQueryable<TEntity> data) where TEntity : class
-	    {
-	        var mock = new Mock<DbQuery<TEntity>>();
-	        var enumerable = new TestAsyncEnumerable<TEntity>(data);
-            mock.As<IAsyncEnumerable<TEntity>>().ConfigureAsyncEnumerableCalls(enumerable);
-            mock.As<IQueryable<TEntity>>().ConfigureQueryableCalls(enumerable, data);
-            return mock;
-        }
+		[Obsolete]
+		public static Mock<DbQuery<TEntity>> BuildMockDbQuery<TEntity>(this IQueryable<TEntity> data)
+			where TEntity : class
+		{
+			var mock = new Mock<DbQuery<TEntity>>();
+			var enumerable = new TestAsyncEnumerable<TEntity>(data);
+			mock.As<IAsyncEnumerable<TEntity>>().ConfigureAsyncEnumerableCalls(enumerable);
+			mock.As<IQueryable<TEntity>>().ConfigureQueryableCalls(enumerable, data);
+			return mock;
+		}
 
-        private static void ConfigureQueryableCalls<TEntity>(this Mock<IQueryable<TEntity>> mock, IQueryProvider queryProvider, IQueryable<TEntity> data)
-            where TEntity : class
-        {
-            mock.Setup(m => m.Provider).Returns(queryProvider);
-            mock.Setup(m => m.Expression).Returns(data?.Expression);
-            mock.Setup(m => m.ElementType).Returns(data?.ElementType);
-            mock.Setup(m => m.GetEnumerator()).Returns(data?.GetEnumerator());
-        }
+		private static void ConfigureQueryableCalls<TEntity>(
+			this Mock<IQueryable<TEntity>> mock,
+			IQueryProvider queryProvider,
+			IQueryable<TEntity> data) where TEntity : class
+		{
+			mock.Setup(m => m.Provider).Returns(queryProvider);
+			mock.Setup(m => m.Expression).Returns(data?.Expression);
+			mock.Setup(m => m.ElementType).Returns(data?.ElementType);
+			mock.Setup(m => m.GetEnumerator()).Returns(data?.GetEnumerator());
+		}
 
-        private static void ConfigureAsyncEnumerableCalls<TEntity>(
-            this Mock<IAsyncEnumerable<TEntity>> mock,
-            IAsyncEnumerable<TEntity> enumerable)
-        {
-            mock.Setup(d => d.GetAsyncEnumerator(It.IsAny<CancellationToken>())).Returns(() => enumerable.GetAsyncEnumerator());
-        }
-    }
+		private static void ConfigureAsyncEnumerableCalls<TEntity>(
+			this Mock<IAsyncEnumerable<TEntity>> mock,
+			IAsyncEnumerable<TEntity> enumerable)
+		{
+			mock.Setup(d => d.GetAsyncEnumerator(It.IsAny<CancellationToken>()))
+				.Returns(() => enumerable.GetAsyncEnumerator());
+		}
+	}
 }

--- a/src/MockQueryable/MockQueryable.Moq/MoqExtensions.cs
+++ b/src/MockQueryable/MockQueryable.Moq/MoqExtensions.cs
@@ -1,5 +1,7 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using Microsoft.EntityFrameworkCore;
 using Moq;
 
@@ -11,7 +13,7 @@ namespace MockQueryable.Moq
 		{
 			var mock = new Mock<IQueryable<TEntity>>();
 			var enumerable = new TestAsyncEnumerable<TEntity>(data);
-			mock.As<IAsyncEnumerable<TEntity>>().Setup(d => d.GetEnumerator()).Returns(enumerable.GetEnumerator);
+			mock.As<IAsyncEnumerable<TEntity>>().Setup(d => d.GetAsyncEnumerator(It.IsAny<CancellationToken>())).Returns(() => enumerable.GetAsyncEnumerator());
 			mock.As<IQueryable<TEntity>>().Setup(m => m.Provider).Returns(enumerable);
 			mock.As<IQueryable<TEntity>>().Setup(m => m.Expression).Returns(data?.Expression);
 			mock.As<IQueryable<TEntity>>().Setup(m => m.ElementType).Returns(data?.ElementType);
@@ -23,7 +25,7 @@ namespace MockQueryable.Moq
 	    {
 	        var mock = new Mock<DbSet<TEntity>>();
 	        var enumerable = new TestAsyncEnumerable<TEntity>(data);
-	        mock.As<IAsyncEnumerable<TEntity>>().Setup(d => d.GetEnumerator()).Returns(enumerable.GetEnumerator);
+	        mock.As<IAsyncEnumerable<TEntity>>().Setup(d => d.GetAsyncEnumerator(It.IsAny<CancellationToken>())).Returns(() => enumerable.GetAsyncEnumerator());
 	        mock.As<IQueryable<TEntity>>().Setup(m => m.Provider).Returns(enumerable);
 	        mock.As<IQueryable<TEntity>>().Setup(m => m.Expression).Returns(data?.Expression);
 	        mock.As<IQueryable<TEntity>>().Setup(m => m.ElementType).Returns(data?.ElementType);
@@ -31,12 +33,13 @@ namespace MockQueryable.Moq
 	        return mock;
         }
 
+        [Obsolete]
         public static Mock<DbQuery<TEntity>> BuildMockDbQuery<TEntity>(this IQueryable<TEntity> data) where TEntity : class
 	    {
 	        var mock = new Mock<DbQuery<TEntity>>();
 	        var enumerable = new TestAsyncEnumerable<TEntity>(data);
-	        mock.As<IAsyncEnumerable<TEntity>>().Setup(d => d.GetEnumerator()).Returns(enumerable.GetEnumerator);
-	        mock.As<IQueryable<TEntity>>().Setup(m => m.Provider).Returns(enumerable);
+            mock.As<IAsyncEnumerable<TEntity>>().Setup(d => d.GetAsyncEnumerator(It.IsAny<CancellationToken>())).Returns(() => enumerable.GetAsyncEnumerator());
+            mock.As<IQueryable<TEntity>>().Setup(m => m.Provider).Returns(enumerable);
 	        mock.As<IQueryable<TEntity>>().Setup(m => m.Expression).Returns(data?.Expression);
 	        mock.As<IQueryable<TEntity>>().Setup(m => m.ElementType).Returns(data?.ElementType);
 	        mock.As<IQueryable<TEntity>>().Setup(m => m.GetEnumerator()).Returns(data?.GetEnumerator());

--- a/src/MockQueryable/MockQueryable.NSubstitute/MockQueryable.NSubstitute.csproj
+++ b/src/MockQueryable/MockQueryable.NSubstitute/MockQueryable.NSubstitute.csproj
@@ -1,18 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <Authors>Roman Titov</Authors>
     <Company></Company>
-    <Version>1.1.0</Version>
+    <Version>1.2.0-alpha</Version>
     <Description>Extension for mocking Entity Framework Core operations such ToListAsync, FirstOrDefaultAsync etc. by NSubstitute
 When writing tests for your application it is often desirable to avoid hitting the database. The extension allows you to achieve this by creating a context – with behavior defined by your tests – that makes use of in-memory data.</Description>
     <PackageProjectUrl>https://github.com/romantitov/MockQueryable</PackageProjectUrl>
     <RepositoryUrl>https://github.com/romantitov/MockQueryable</RepositoryUrl>
     <PackageTags>NSubstitute EntityFrameworkCore Queryable mock EF UnitTests</PackageTags>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <AssemblyVersion>1.1.0.0</AssemblyVersion>
-    <FileVersion>1.1.0.0</FileVersion>
+    <AssemblyVersion>1.2.0.0</AssemblyVersion>
+    <FileVersion>1.2.0.0</FileVersion>
     <PackageReleaseNotes>AutoMapper support</PackageReleaseNotes>
   </PropertyGroup>
 

--- a/src/MockQueryable/MockQueryable.NSubstitute/NSubstituteExtensions.cs
+++ b/src/MockQueryable/MockQueryable.NSubstitute/NSubstituteExtensions.cs
@@ -7,50 +7,52 @@ using NSubstitute;
 
 namespace MockQueryable.NSubstitute
 {
-    public static class NSubstituteExtensions
-    {
-        public static IQueryable<TEntity> BuildMock<TEntity>(this IQueryable<TEntity> data) where TEntity : class
-        {
-            var mock = Substitute.For<IQueryable<TEntity>, IAsyncEnumerable<TEntity>> ();
-            var enumerable = new TestAsyncEnumerable<TEntity>(data);
-            ((IAsyncEnumerable<TEntity>)mock).ConfigureAsyncEnumerableCalls(enumerable);
-            mock.ConfigureQueryableCalls(enumerable, data);
-            return mock;
-        }
+	public static class NSubstituteExtensions
+	{
+		public static IQueryable<TEntity> BuildMock<TEntity>(this IQueryable<TEntity> data) where TEntity : class
+		{
+			var mock = Substitute.For<IQueryable<TEntity>, IAsyncEnumerable<TEntity>>();
+			var enumerable = new TestAsyncEnumerable<TEntity>(data);
+			((IAsyncEnumerable<TEntity>) mock).ConfigureAsyncEnumerableCalls(enumerable);
+			mock.ConfigureQueryableCalls(enumerable, data);
+			return mock;
+		}
 
-        public static DbSet<TEntity> BuildMockDbSet<TEntity>(this IQueryable<TEntity> data) where TEntity : class
-        {
-            var mock = Substitute.For<DbSet<TEntity>, IQueryable<TEntity>, IAsyncEnumerable<TEntity>>();
-            var enumerable = new TestAsyncEnumerable<TEntity>(data);
-            mock.ConfigureAsyncEnumerableCalls(enumerable);
-            mock.ConfigureQueryableCalls(enumerable, data);
-            return mock;
-        }
+		public static DbSet<TEntity> BuildMockDbSet<TEntity>(this IQueryable<TEntity> data) where TEntity : class
+		{
+			var mock = Substitute.For<DbSet<TEntity>, IQueryable<TEntity>, IAsyncEnumerable<TEntity>>();
+			var enumerable = new TestAsyncEnumerable<TEntity>(data);
+			mock.ConfigureAsyncEnumerableCalls(enumerable);
+			mock.ConfigureQueryableCalls(enumerable, data);
+			return mock;
+		}
 
-        [Obsolete]
-        public static DbQuery<TEntity> BuildMockDbQuery<TEntity>(this IQueryable<TEntity> data) where TEntity : class
-        {
-            var mock = Substitute.For<DbQuery<TEntity>, IQueryable<TEntity>, IAsyncEnumerable<TEntity>>();
-            var enumerable = new TestAsyncEnumerable<TEntity>(data);
-            mock.ConfigureAsyncEnumerableCalls(enumerable);
-            mock.ConfigureQueryableCalls(enumerable, data);
-            return mock;
-        }
+		[Obsolete]
+		public static DbQuery<TEntity> BuildMockDbQuery<TEntity>(this IQueryable<TEntity> data) where TEntity : class
+		{
+			var mock = Substitute.For<DbQuery<TEntity>, IQueryable<TEntity>, IAsyncEnumerable<TEntity>>();
+			var enumerable = new TestAsyncEnumerable<TEntity>(data);
+			mock.ConfigureAsyncEnumerableCalls(enumerable);
+			mock.ConfigureQueryableCalls(enumerable, data);
+			return mock;
+		}
 
-        private static void ConfigureQueryableCalls<TEntity>(this IQueryable<TEntity> mock, IQueryProvider queryProvider, IQueryable<TEntity> data)
-            where TEntity : class
-        {
-            mock.Provider.Returns(queryProvider);
-            mock.Expression.Returns(data?.Expression);
-            mock.ElementType.Returns(data?.ElementType);
-            mock.GetEnumerator().Returns(data?.GetEnumerator());
-        }
+		private static void ConfigureQueryableCalls<TEntity>(
+			this IQueryable<TEntity> mock,
+			IQueryProvider queryProvider,
+			IQueryable<TEntity> data) where TEntity : class
+		{
+			mock.Provider.Returns(queryProvider);
+			mock.Expression.Returns(data?.Expression);
+			mock.ElementType.Returns(data?.ElementType);
+			mock.GetEnumerator().Returns(data?.GetEnumerator());
+		}
 
-        private static void ConfigureAsyncEnumerableCalls<TEntity>(
-            this IAsyncEnumerable<TEntity> mock,
-            IAsyncEnumerable<TEntity> enumerable)
-        {
-            mock.GetAsyncEnumerator(Arg.Any<CancellationToken>()).Returns(args => enumerable.GetAsyncEnumerator());
-        }
-    }
+		private static void ConfigureAsyncEnumerableCalls<TEntity>(
+			this IAsyncEnumerable<TEntity> mock,
+			IAsyncEnumerable<TEntity> enumerable)
+		{
+			mock.GetAsyncEnumerator(Arg.Any<CancellationToken>()).Returns(args => enumerable.GetAsyncEnumerator());
+		}
+	}
 }

--- a/src/MockQueryable/MockQueryable.NSubstitute/NSubstituteExtensions.cs
+++ b/src/MockQueryable/MockQueryable.NSubstitute/NSubstituteExtensions.cs
@@ -1,5 +1,7 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using Microsoft.EntityFrameworkCore;
 using NSubstitute;
 
@@ -11,7 +13,7 @@ namespace MockQueryable.NSubstitute
         {
             var mock = Substitute.For<IQueryable<TEntity>, IAsyncEnumerable<TEntity>> ();
             var enumerable = new TestAsyncEnumerable<TEntity>(data);
-            ((IAsyncEnumerable<TEntity>)mock).GetEnumerator().Returns(enumerable.GetEnumerator());
+            ((IAsyncEnumerable<TEntity>)mock).GetAsyncEnumerator(Arg.Any<CancellationToken>()).Returns(args => enumerable.GetAsyncEnumerator());
             mock.Provider.Returns(enumerable);
             mock.Expression.Returns(data?.Expression);
             mock.ElementType.Returns(data?.ElementType);
@@ -23,7 +25,7 @@ namespace MockQueryable.NSubstitute
         {
             var mock = Substitute.For<DbSet<TEntity>, IQueryable<TEntity>, IAsyncEnumerable<TEntity>>();
             var enumerable = new TestAsyncEnumerable<TEntity>(data);
-            ((IAsyncEnumerable<TEntity>)mock).GetEnumerator().Returns(enumerable.GetEnumerator());
+            ((IAsyncEnumerable<TEntity>)mock).GetAsyncEnumerator(Arg.Any<CancellationToken>()).Returns(args => enumerable.GetAsyncEnumerator());
             var queryable = ((IQueryable<TEntity>)mock);
             queryable.Provider.Returns(enumerable);
             queryable.Expression.Returns(data?.Expression);
@@ -32,11 +34,12 @@ namespace MockQueryable.NSubstitute
             return mock;
         }
 
+        [Obsolete]
         public static DbQuery<TEntity> BuildMockDbQuery<TEntity>(this IQueryable<TEntity> data) where TEntity : class
         {
             var mock = Substitute.For<DbQuery<TEntity>, IQueryable<TEntity>, IAsyncEnumerable<TEntity>>();
             var enumerable = new TestAsyncEnumerable<TEntity>(data);
-            ((IAsyncEnumerable<TEntity>)mock).GetEnumerator().Returns(enumerable.GetEnumerator());
+            ((IAsyncEnumerable<TEntity>)mock).GetAsyncEnumerator(Arg.Any<CancellationToken>()).Returns(args => enumerable.GetAsyncEnumerator());
             var queryable = ((IQueryable<TEntity>)mock);
             queryable.Provider.Returns(enumerable);
             queryable.Expression.Returns(data?.Expression);

--- a/src/MockQueryable/MockQueryable.NSubstitute/NSubstituteExtensions.cs
+++ b/src/MockQueryable/MockQueryable.NSubstitute/NSubstituteExtensions.cs
@@ -13,11 +13,8 @@ namespace MockQueryable.NSubstitute
         {
             var mock = Substitute.For<IQueryable<TEntity>, IAsyncEnumerable<TEntity>> ();
             var enumerable = new TestAsyncEnumerable<TEntity>(data);
-            ((IAsyncEnumerable<TEntity>)mock).GetAsyncEnumerator(Arg.Any<CancellationToken>()).Returns(args => enumerable.GetAsyncEnumerator());
-            mock.Provider.Returns(enumerable);
-            mock.Expression.Returns(data?.Expression);
-            mock.ElementType.Returns(data?.ElementType);
-            mock.GetEnumerator().Returns(data?.GetEnumerator());
+            ((IAsyncEnumerable<TEntity>)mock).ConfigureAsyncEnumerableCalls(enumerable);
+            mock.ConfigureQueryableCalls(enumerable, data);
             return mock;
         }
 
@@ -25,12 +22,8 @@ namespace MockQueryable.NSubstitute
         {
             var mock = Substitute.For<DbSet<TEntity>, IQueryable<TEntity>, IAsyncEnumerable<TEntity>>();
             var enumerable = new TestAsyncEnumerable<TEntity>(data);
-            ((IAsyncEnumerable<TEntity>)mock).GetAsyncEnumerator(Arg.Any<CancellationToken>()).Returns(args => enumerable.GetAsyncEnumerator());
-            var queryable = ((IQueryable<TEntity>)mock);
-            queryable.Provider.Returns(enumerable);
-            queryable.Expression.Returns(data?.Expression);
-            queryable.ElementType.Returns(data?.ElementType);
-            queryable.GetEnumerator().Returns(data?.GetEnumerator());
+            mock.ConfigureAsyncEnumerableCalls(enumerable);
+            mock.ConfigureQueryableCalls(enumerable, data);
             return mock;
         }
 
@@ -39,13 +32,25 @@ namespace MockQueryable.NSubstitute
         {
             var mock = Substitute.For<DbQuery<TEntity>, IQueryable<TEntity>, IAsyncEnumerable<TEntity>>();
             var enumerable = new TestAsyncEnumerable<TEntity>(data);
-            ((IAsyncEnumerable<TEntity>)mock).GetAsyncEnumerator(Arg.Any<CancellationToken>()).Returns(args => enumerable.GetAsyncEnumerator());
-            var queryable = ((IQueryable<TEntity>)mock);
-            queryable.Provider.Returns(enumerable);
-            queryable.Expression.Returns(data?.Expression);
-            queryable.ElementType.Returns(data?.ElementType);
-            queryable.GetEnumerator().Returns(data?.GetEnumerator());
+            mock.ConfigureAsyncEnumerableCalls(enumerable);
+            mock.ConfigureQueryableCalls(enumerable, data);
             return mock;
+        }
+
+        private static void ConfigureQueryableCalls<TEntity>(this IQueryable<TEntity> mock, IQueryProvider queryProvider, IQueryable<TEntity> data)
+            where TEntity : class
+        {
+            mock.Provider.Returns(queryProvider);
+            mock.Expression.Returns(data?.Expression);
+            mock.ElementType.Returns(data?.ElementType);
+            mock.GetEnumerator().Returns(data?.GetEnumerator());
+        }
+
+        private static void ConfigureAsyncEnumerableCalls<TEntity>(
+            this IAsyncEnumerable<TEntity> mock,
+            IAsyncEnumerable<TEntity> enumerable)
+        {
+            mock.GetAsyncEnumerator(Arg.Any<CancellationToken>()).Returns(args => enumerable.GetAsyncEnumerator());
         }
     }
 }

--- a/src/MockQueryable/MockQueryable.Sample/MockQueryable.Sample.csproj
+++ b/src/MockQueryable/MockQueryable.Sample/MockQueryable.Sample.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="8.0.0" />
     <PackageReference Include="FakeItEasy" Version="5.1.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.0.0-preview8.19405.11" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.0.0-preview9.19423.6" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="Moq" Version="4.8.3" />
     <PackageReference Include="NSubstitute" Version="3.1.0" />

--- a/src/MockQueryable/MockQueryable.Sample/MockQueryable.Sample.csproj
+++ b/src/MockQueryable/MockQueryable.Sample/MockQueryable.Sample.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="8.0.0" />
     <PackageReference Include="FakeItEasy" Version="5.1.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.0.0-preview7.19362.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.0.0-preview8.19405.11" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="Moq" Version="4.8.3" />
     <PackageReference Include="NSubstitute" Version="3.1.0" />

--- a/src/MockQueryable/MockQueryable.Sample/MockQueryable.Sample.csproj
+++ b/src/MockQueryable/MockQueryable.Sample/MockQueryable.Sample.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="8.0.0" />
     <PackageReference Include="FakeItEasy" Version="5.1.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.2.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.0.0-preview7.19362.6" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="Moq" Version="4.8.3" />
     <PackageReference Include="NSubstitute" Version="3.1.0" />

--- a/src/MockQueryable/MockQueryable/MockQueryable.csproj
+++ b/src/MockQueryable/MockQueryable/MockQueryable.csproj
@@ -22,7 +22,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.0.0-preview8.19405.11" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.0.0-preview9.19423.6" />
   </ItemGroup>
 
 </Project>

--- a/src/MockQueryable/MockQueryable/MockQueryable.csproj
+++ b/src/MockQueryable/MockQueryable/MockQueryable.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <PackageId>MockQueryable.Core</PackageId>
     <Authors>Roman Titov</Authors>
     <Description>Async operations with generic collections, to provide for collections such List&lt;T&gt; execute EntityFrameworkCore operations such ToListAsync, FirstOrDefaultAsync etc.</Description>
@@ -11,9 +11,9 @@
     <PackageProjectUrl>https://github.com/romantitov/MockQueryable</PackageProjectUrl>
     <RepositoryUrl>https://github.com/romantitov/MockQueryable</RepositoryUrl>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>1.1.0</Version>
-    <AssemblyVersion>1.1.0.0</AssemblyVersion>
-    <FileVersion>1.1.0.0</FileVersion>
+    <Version>1.2.0-alpha</Version>
+    <AssemblyVersion>1.2.0.0</AssemblyVersion>
+    <FileVersion>1.2.0.0</FileVersion>
     <Company></Company>
   </PropertyGroup>
 
@@ -22,7 +22,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.2.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.0.0-preview7.19362.6" />
   </ItemGroup>
 
 </Project>

--- a/src/MockQueryable/MockQueryable/MockQueryable.csproj
+++ b/src/MockQueryable/MockQueryable/MockQueryable.csproj
@@ -22,7 +22,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.0.0-preview7.19362.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.0.0-preview8.19405.11" />
   </ItemGroup>
 
 </Project>

--- a/src/MockQueryable/MockQueryable/TestAsyncEnumerable.cs
+++ b/src/MockQueryable/MockQueryable/TestAsyncEnumerable.cs
@@ -30,19 +30,20 @@ namespace MockQueryable
 
 		public IQueryable CreateQuery(Expression expression)
 		{
-            if (expression is MethodCallExpression m)
-            {
-                var resultType = m.Method.ReturnType; // it should be IQueryable<T>
-                var tElement = resultType.GetGenericArguments().First();
-                var queryType = typeof(TestAsyncEnumerable<>).MakeGenericType(tElement);
-                return (IQueryable)Activator.CreateInstance(queryType, expression);
-            }
-            return new TestAsyncEnumerable<T>(expression);
+			if (expression is MethodCallExpression m)
+			{
+				var resultType = m.Method.ReturnType; // it should be IQueryable<T>
+				var tElement = resultType.GetGenericArguments().First();
+				var queryType = typeof(TestAsyncEnumerable<>).MakeGenericType(tElement);
+				return (IQueryable) Activator.CreateInstance(queryType, expression);
+			}
+
+			return new TestAsyncEnumerable<T>(expression);
 		}
 
 		public IQueryable<TEntity> CreateQuery<TEntity>(Expression expression)
 		{
-            return new TestAsyncEnumerable<TEntity>(expression);
+			return new TestAsyncEnumerable<TEntity>(expression);
 		}
 
 		public object Execute(Expression expression)
@@ -56,17 +57,20 @@ namespace MockQueryable
 		}
 
 		public TResult ExecuteAsync<TResult>(Expression expression, CancellationToken cancellationToken)
-        {
-            var expectedResultType = typeof(TResult).GetGenericArguments()[0];
-            var executionResult = typeof(IQueryProvider)
-                .GetMethod(name: nameof(IQueryProvider.Execute), genericParameterCount: 1, types: new []{typeof(Expression)})
-                .MakeGenericMethod(expectedResultType)
-                .Invoke(this, new[] { expression });
+		{
+			var expectedResultType = typeof(TResult).GetGenericArguments()[0];
+			var executionResult = typeof(IQueryProvider)
+				.GetMethod(
+					name: nameof(IQueryProvider.Execute),
+					genericParameterCount: 1,
+					types: new[] {typeof(Expression)})
+				.MakeGenericMethod(expectedResultType)
+				.Invoke(this, new[] {expression});
 
-            return (TResult)typeof(Task).GetMethod(nameof(Task.FromResult))
-                .MakeGenericMethod(expectedResultType)
-                .Invoke(null, new[] { executionResult });
-        }
+			return (TResult) typeof(Task).GetMethod(nameof(Task.FromResult))
+				.MakeGenericMethod(expectedResultType)
+				.Invoke(null, new[] {executionResult});
+		}
 
 
 		IEnumerator<T> IEnumerable<T>.GetEnumerator()

--- a/src/MockQueryable/MockQueryable/TestAsyncEnumerator.cs
+++ b/src/MockQueryable/MockQueryable/TestAsyncEnumerator.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Threading;
 using System.Threading.Tasks;
 
 namespace MockQueryable
@@ -16,13 +15,15 @@ namespace MockQueryable
 
 		public T Current => _enumerator.Current;
 
-		public void Dispose()
+		public ValueTask DisposeAsync()
 		{
-		}
+            _enumerator.Dispose();
+            return new ValueTask();
+        }
 
-		public Task<bool> MoveNext(CancellationToken cancellationToken)
-		{
-			return Task.FromResult(_enumerator.MoveNext());
-		}
-	}
+		public ValueTask<bool> MoveNextAsync()
+        {
+            return new ValueTask<bool>(_enumerator.MoveNext());
+        }
+    }
 }

--- a/src/MockQueryable/MockQueryable/TestAsyncEnumerator.cs
+++ b/src/MockQueryable/MockQueryable/TestAsyncEnumerator.cs
@@ -17,13 +17,13 @@ namespace MockQueryable
 
 		public ValueTask DisposeAsync()
 		{
-            _enumerator.Dispose();
-            return new ValueTask();
-        }
+			_enumerator.Dispose();
+			return new ValueTask();
+		}
 
 		public ValueTask<bool> MoveNextAsync()
-        {
-            return new ValueTask<bool>(_enumerator.MoveNext());
-        }
-    }
+		{
+			return new ValueTask<bool>(_enumerator.MoveNext());
+		}
+	}
 }


### PR DESCRIPTION
# PR Details

Updated the project for .NET Standard 2.1 and EF Core 3.0 preview 8.

## Description

- Changed target frameworks to latest previews of .NET Standard 2.1 and the test projects' target framework to latest preview of .NET Core 3.0. 
- Updated `MockQueryable` to latest preview of EntityFramework Core 3.0 and updated the implementations of `TestAsyncEnumerable` and `TestAsyncEnumerator` to conform to interface changes in `IAsyncEnumerable`, `IAsyncEnumerator` and `IAsyncQueryProvider`. 
- Marked `BuildDbQuery` methods as obsolete, as `DbQuery` itself is deprecated in EF Core 3.0.
- Also took the liberty to remove duplications from mock extensions targeting specific mocking frameworks, see the `ConfigureQueryableCalls` and `ConfigureAsyncEnumerableCalls` methods.

## Related Issue

#17 

## How Has This Been Tested

No new tests added. All regression tests pass with the new async implementations.

## Checklist

- [x] My code follows the code style of this project. (I assumed that since most of the code is written with tabs as indents then it's the code style for the project, so I unified all indents in edited files to be tabs).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
