### PR TITLE
return enumerable lazily to allow for mutation of base enumerable

### DIFF
--- a/src/MockQueryable/MockQueryable.FakeItEasy/FakeItEasyExtensions.cs
+++ b/src/MockQueryable/MockQueryable.FakeItEasy/FakeItEasyExtensions.cs
@@ -49,7 +49,7 @@ namespace MockQueryable.FakeItEasy
 			A.CallTo(() => mock.Provider).Returns(queryProvider);
 			A.CallTo(() => mock.Expression).Returns(data?.Expression);
 			A.CallTo(() => mock.ElementType).Returns(data?.ElementType);
-			A.CallTo(() => mock.GetEnumerator()).Returns(data?.GetEnumerator());
+			A.CallTo(() => mock.GetEnumerator()).ReturnsLazily(() => data?.GetEnumerator());
 		}
 
 		private static void ConfigureAsyncEnumerableCalls<TEntity>(

--- a/src/MockQueryable/MockQueryable.Moq/MoqExtensions.cs
+++ b/src/MockQueryable/MockQueryable.Moq/MoqExtensions.cs
@@ -46,7 +46,7 @@ namespace MockQueryable.Moq
 			mock.Setup(m => m.Provider).Returns(queryProvider);
 			mock.Setup(m => m.Expression).Returns(data?.Expression);
 			mock.Setup(m => m.ElementType).Returns(data?.ElementType);
-			mock.Setup(m => m.GetEnumerator()).Returns(data?.GetEnumerator());
+			mock.Setup(m => m.GetEnumerator()).Returns(() => data?.GetEnumerator());
 		}
 
 		private static void ConfigureAsyncEnumerableCalls<TEntity>(

--- a/src/MockQueryable/MockQueryable.NSubstitute/NSubstituteExtensions.cs
+++ b/src/MockQueryable/MockQueryable.NSubstitute/NSubstituteExtensions.cs
@@ -45,7 +45,7 @@ namespace MockQueryable.NSubstitute
 			mock.Provider.Returns(queryProvider);
 			mock.Expression.Returns(data?.Expression);
 			mock.ElementType.Returns(data?.ElementType);
-			mock.GetEnumerator().Returns(data?.GetEnumerator());
+			mock.GetEnumerator().Returns(info => data?.GetEnumerator());
 		}
 
 		private static void ConfigureAsyncEnumerableCalls<TEntity>(

--- a/src/MockQueryable/MockQueryable.Sample/MyServiceNSubstituteTests.cs
+++ b/src/MockQueryable/MockQueryable.Sample/MyServiceNSubstituteTests.cs
@@ -147,11 +147,20 @@ namespace MockQueryable.Sample
         public async Task DbSetCreateUser(string firstName, string lastName, DateTime dateOfBirth)
         {
             //arrange
-            var mock = new List<UserEntity>().AsQueryable().BuildMockDbSet();
+            var userEntities = new List<UserEntity>();
+            var mock = userEntities.AsQueryable().BuildMockDbSet();
+            mock.AddAsync(Arg.Any<UserEntity>())
+                .Returns(info => null)
+                .AndDoes(info => userEntities.Add(info.Arg<UserEntity>()));
             var userRepository = new TestDbSetRepository(mock);
             var service = new MyService(userRepository);
             //act
             await service.CreateUserIfNotExist(firstName, lastName, dateOfBirth);
+            // assert
+            var entity = mock.Single();
+            Assert.AreEqual(firstName, entity.FirstName);
+            Assert.AreEqual(lastName, entity.LastName);
+            Assert.AreEqual(dateOfBirth, entity.DateOfBirth);
         }
 
         [TestCase("01/20/2012", "06/20/2018", 5)]


### PR DESCRIPTION
#2  Description

This PR resolves issue #23 to allow for mutation of the base collection at the consumers discretion by lazily returning the enumerator. I have added to existing tests as they didn't have asserts to cover these changes. See examples in the sample tests part of the changeset.

I really like this project. Thank you for creating it.

## Related Issue

Issue #23

## How Has This Been Tested

I tested it in a personal project as well as this project's sample tests that are part of this PR

## Checklist

- [ x] My code follows the code style of this project.
- [ x] I have added tests to cover my changes.
- [ x] All new and existing tests passed.
