### PR TITLE
Add support for ef core 3.1.1 with Moq

### DIFF
--- a/src/MockQueryable/MockQueryable.Moq/MoqExtensions.cs
+++ b/src/MockQueryable/MockQueryable.Moq/MoqExtensions.cs
@@ -24,6 +24,7 @@ namespace MockQueryable.Moq
 			var enumerable = new TestAsyncEnumerable<TEntity>(data);
 			mock.As<IAsyncEnumerable<TEntity>>().ConfigureAsyncEnumerableCalls(enumerable);
 			mock.As<IQueryable<TEntity>>().ConfigureQueryableCalls(enumerable, data);
+			mock.ConfigureDbSetCalls();
 			return mock;
 		}
 
@@ -36,6 +37,13 @@ namespace MockQueryable.Moq
 			mock.As<IAsyncEnumerable<TEntity>>().ConfigureAsyncEnumerableCalls(enumerable);
 			mock.As<IQueryable<TEntity>>().ConfigureQueryableCalls(enumerable, data);
 			return mock;
+		}
+
+		private static void ConfigureDbSetCalls<TEntity>(this Mock<DbSet<TEntity>> mock) 
+			where TEntity : class
+		{
+			mock.Setup(m => m.AsQueryable()).Returns(mock.Object);
+			mock.Setup(m => m.AsAsyncEnumerable()).Returns(mock.Object);
 		}
 
 		private static void ConfigureQueryableCalls<TEntity>(

--- a/src/MockQueryable/MockQueryable.Sample/MockQueryable.Sample.csproj
+++ b/src/MockQueryable/MockQueryable.Sample/MockQueryable.Sample.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="8.0.0" />
     <PackageReference Include="FakeItEasy" Version="5.1.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
     <PackageReference Include="Moq" Version="4.8.3" />
     <PackageReference Include="NSubstitute" Version="4.2.1" />

--- a/src/MockQueryable/MockQueryable.Sample/MyService.cs
+++ b/src/MockQueryable/MockQueryable.Sample/MyService.cs
@@ -85,6 +85,8 @@ namespace MockQueryable.Sample
 		IQueryable<UserEntity> GetQueryable();
 
 		Task CreateUser(UserEntity user);
+
+		List<UserEntity> GetAll();
 	}
 
 

--- a/src/MockQueryable/MockQueryable.Sample/MyServiceMoqTests.cs
+++ b/src/MockQueryable/MockQueryable.Sample/MyServiceMoqTests.cs
@@ -191,6 +191,23 @@ namespace MockQueryable.Sample
             Assert.AreEqual(expectedCount, result.Count);
         }
 
-
-    }
+		[TestCase]
+		public void DbSetGetAllUserEntity() {
+			//arrange
+			var users = new List<UserEntity>
+			{
+				new UserEntity{FirstName = "FirstName1", LastName = "LastName", DateOfBirth = DateTime.Parse("01/20/2012",UsCultureInfo.DateTimeFormat)},
+				new UserEntity{FirstName = "FirstName2", LastName = "LastName", DateOfBirth = DateTime.Parse("01/20/2012",UsCultureInfo.DateTimeFormat)},
+				new UserEntity{FirstName = "FirstName3", LastName = "LastName", DateOfBirth = DateTime.Parse("01/20/2012",UsCultureInfo.DateTimeFormat)},
+				new UserEntity{FirstName = "FirstName3", LastName = "LastName", DateOfBirth = DateTime.Parse("03/20/2012",UsCultureInfo.DateTimeFormat)},
+				new UserEntity{FirstName = "FirstName5", LastName = "LastName", DateOfBirth = DateTime.Parse("01/20/2018",UsCultureInfo.DateTimeFormat)},
+			};
+			var mock = users.AsQueryable().BuildMockDbSet();
+			var userRepository = new TestDbSetRepository(mock.Object);
+			//act
+			var result = userRepository.GetAll();
+			//assert
+			Assert.AreEqual(users.Count, result.Count);
+		}
+	}
 }

--- a/src/MockQueryable/MockQueryable.Sample/TestDbSetRepository.cs
+++ b/src/MockQueryable/MockQueryable.Sample/TestDbSetRepository.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 
@@ -20,6 +21,10 @@ namespace MockQueryable.Sample
         public async Task CreateUser(UserEntity user)
         {
             await _dbSet.AddAsync(user);
+        }
+
+        public List<UserEntity> GetAll() {
+            return _dbSet.AsQueryable().ToList();
         }
     }
 }

--- a/src/MockQueryable/MockQueryable/MockQueryable.csproj
+++ b/src/MockQueryable/MockQueryable/MockQueryable.csproj
@@ -35,7 +35,7 @@
 
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
# PR Details

Migrate to EF Core 3.1.1 and support the new overrides when using Moq.

## Description

In EF Core 3.1.1, DbSet has new methods to override for the mocks to behave as expected. 

## Related Issue

#25 

## How Has This Been Tested

A test has been added that fails with the current code when using EF Core 3.1.1.
Changes to the code have been made to make this test pass when using EF Core 3.1.1.
All other test still pass. 

## Checklist

- [ x ] My code follows the code style of this project.
- [ x ] I have added tests to cover my changes.
- [ x ] All new and existing tests passed.
