### PR TITLE
Restore support for netstandard2.0

### DIFF
--- a/src/MockQueryable/MockQueryable.FakeItEasy/MockQueryable.FakeItEasy.csproj
+++ b/src/MockQueryable/MockQueryable.FakeItEasy/MockQueryable.FakeItEasy.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>MockQueryable.FakeItEasy</PackageId>
     <Authors>Roman Titov</Authors>
 	  <Description>

--- a/src/MockQueryable/MockQueryable.Moq/MockQueryable.Moq.csproj
+++ b/src/MockQueryable/MockQueryable.Moq/MockQueryable.Moq.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
 	  <PackageId>MockQueryable.Moq</PackageId>
     <Authors>Roman Titov</Authors>
 		<Description>

--- a/src/MockQueryable/MockQueryable.NSubstitute/MockQueryable.NSubstitute.csproj
+++ b/src/MockQueryable/MockQueryable.NSubstitute/MockQueryable.NSubstitute.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
 	  <PackageId>MockQueryable.NSubstitute</PackageId>
 		<Authors>Roman Titov</Authors>
 	  <Description>

--- a/src/MockQueryable/MockQueryable/MockQueryable.csproj
+++ b/src/MockQueryable/MockQueryable/MockQueryable.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>MockQueryable.Core</PackageId>
 		<Authors>Roman Titov</Authors>
 	  <Description>

--- a/src/MockQueryable/MockQueryable/TestAsyncEnumerable.cs
+++ b/src/MockQueryable/MockQueryable/TestAsyncEnumerable.cs
@@ -60,10 +60,9 @@ namespace MockQueryable
 		{
 			var expectedResultType = typeof(TResult).GetGenericArguments()[0];
 			var executionResult = typeof(IQueryProvider)
-				.GetMethod(
-					name: nameof(IQueryProvider.Execute),
-					genericParameterCount: 1,
-					types: new[] {typeof(Expression)})
+				.GetMethods()
+				.Where(method => method.Name == nameof(IQueryProvider.Execute) && method.IsGenericMethod)
+				.First()
 				.MakeGenericMethod(expectedResultType)
 				.Invoke(this, new[] {expression});
 


### PR DESCRIPTION
## Description

We would like to use this library in a project that does not support netstandard2.1 and it seems that this library and it's dependencies also work with netstandard2.0. This PR restores support for netstandard2.0 to make that possible. We would like to avoid duplicating your code in our project and this is why we submitted this PR.

## How Has This Been Tested

In a project where we would like to use this library we added a reference to this project on disk and used `.AsQueryable().BuildMockDbSet()`. And in that test we also hit the `ExecuteAsync` method that has been changed because  `genericParameterCount` is not supported in netstandard2.0.

## Checklist

- [x] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
