### PR TITLE
Added support for expression when using the IEnumerable constructor.

### DIFF
--- a/src/MockQueryable/MockQueryable/TestAsyncEnumerable.cs
+++ b/src/MockQueryable/MockQueryable/TestAsyncEnumerable.cs
@@ -21,6 +21,7 @@ namespace MockQueryable
 		public TestAsyncEnumerable(IEnumerable<T> enumerable)
 		{
 			_enumerable = enumerable;
+			Expression = enumerable.AsQueryable().Expression;
 		}
 
 		public IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default)


### PR DESCRIPTION
# PR Details

This PR adds support for the following statement:

```C#
var enumerable = new TestAsyncEnumerable<string>(new[] { "a", "bb" });
var result = enumerable.Where(value => value.Length > 1).ToList();
```

## Description

I would like to use this library to help with the mocking of `DocumentDb` queries. Mocking these results requires me to implement a class `IDocumentQuery<T>` and I would want to inherit from `TestAsyncEnumerable<T>` to reuse some of the code that was already written.

But calling `Where` on `TestAsyncEnumerable<T>` does not work because the `Expression` property is null. And this PR sets the `Expression` to a value that just returns the enumerable.

## Checklist

- [x] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
