### PR TITLE
[PR] Fix mocking of IAsyncEnumerable from DbSet using NSubstitute

### DIFF
--- a/src/MockQueryable/MockQueryable.NSubstitute/NSubstituteExtensions.cs
+++ b/src/MockQueryable/MockQueryable.NSubstitute/NSubstituteExtensions.cs
@@ -1,14 +1,14 @@
-﻿using System;
+﻿using Microsoft.EntityFrameworkCore;
+using MockQueryable.EntityFrameworkCore;
+using NSubstitute;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
-using Microsoft.EntityFrameworkCore;
-using MockQueryable.EntityFrameworkCore;
-using NSubstitute;
+using System.Threading.Tasks;
 
 namespace MockQueryable.NSubstitute
 {
-	public static class NSubstituteExtensions
+    public static class NSubstituteExtensions
 	{
 		public static IQueryable<TEntity> BuildMock<TEntity>(this IQueryable<TEntity> data) where TEntity : class
 		{
@@ -23,8 +23,11 @@ namespace MockQueryable.NSubstitute
 		{
 			var mock = Substitute.For<DbSet<TEntity>, IQueryable<TEntity>, IAsyncEnumerable<TEntity>>();
 			var enumerable = new TestAsyncEnumerableEfCore<TEntity>(data);
+
 			mock.ConfigureAsyncEnumerableCalls(enumerable);
 			mock.ConfigureQueryableCalls(enumerable, data);
+			mock.ConfigureDbSetCalls(data);
+
 			return mock;
 		}
 
@@ -46,5 +49,21 @@ namespace MockQueryable.NSubstitute
 		{
 			mock.GetAsyncEnumerator(Arg.Any<CancellationToken>()).Returns(args => enumerable.GetAsyncEnumerator());
 		}
+
+		private static void ConfigureDbSetCalls<TEntity>(this DbSet<TEntity> mock, IQueryable<TEntity> data) where TEntity : class
+		{
+			mock.AsQueryable().Returns(data);
+			mock.AsAsyncEnumerable().Returns(args => CreateAsyncMock(data));
+		}
+
+		private static async IAsyncEnumerable<TEntity> CreateAsyncMock<TEntity>(IQueryable<TEntity> data) where TEntity : class
+        {
+			foreach (TEntity entity in data)
+            {
+				yield return entity;
+            }
+
+			await Task.CompletedTask;
+        }
 	}
 }

--- a/src/MockQueryable/MockQueryable.Sample/MockQueryable.Sample.csproj
+++ b/src/MockQueryable/MockQueryable.Sample/MockQueryable.Sample.csproj
@@ -8,11 +8,12 @@
     <PackageReference Include="AutoMapper" Version="8.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageReference Include="NUnit" Version="3.10.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1">
+    <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="System.Linq.Async" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MockQueryable/MockQueryable.Sample/MyService.cs
+++ b/src/MockQueryable/MockQueryable.Sample/MyService.cs
@@ -87,6 +87,8 @@ namespace MockQueryable.Sample
 		Task CreateUser(UserEntity user);
 
 		List<UserEntity> GetAll();
+		
+		IAsyncEnumerable<UserEntity> GetAllAsync();
 	}
 
 

--- a/src/MockQueryable/MockQueryable.Sample/MyServiceNSubstituteTests.cs
+++ b/src/MockQueryable/MockQueryable.Sample/MyServiceNSubstituteTests.cs
@@ -51,16 +51,10 @@ namespace MockQueryable.Sample
             //arrange
 		    var userRepository = Substitute.For<IUserRepository>();
 		    var service = new MyService(userRepository);
-            var users = new List<UserEntity>
-			{
-				new UserEntity{FirstName = "FirstName1", LastName = "LastName", DateOfBirth = DateTime.Parse("01/20/2012",UsCultureInfo.DateTimeFormat)},
-				new UserEntity{FirstName = "FirstName2", LastName = "LastName", DateOfBirth = DateTime.Parse("01/20/2012",UsCultureInfo.DateTimeFormat)},
-				new UserEntity{FirstName = "FirstName3", LastName = "LastName", DateOfBirth = DateTime.Parse("01/20/2012",UsCultureInfo.DateTimeFormat)},
-				new UserEntity{FirstName = "FirstName3", LastName = "LastName", DateOfBirth = DateTime.Parse("03/20/2012",UsCultureInfo.DateTimeFormat)},
-				new UserEntity{FirstName = "FirstName5", LastName = "LastName", DateOfBirth = DateTime.Parse("01/20/2018",UsCultureInfo.DateTimeFormat)},
-			};
-			//expect
-			var mock = users.AsQueryable().BuildMock();
+            List<UserEntity> users = CreateUserList();
+
+            //expect
+            var mock = users.AsQueryable().BuildMock();
 			userRepository.GetQueryable().Returns(mock);
 			//act
 			var result = await service.GetUserReports(from, to);
@@ -75,14 +69,8 @@ namespace MockQueryable.Sample
         public async Task GetUserReports_AutoMap(DateTime from, DateTime to, int expectedCount)
         {
             //arrange
-            var users = new List<UserEntity>
-            {
-                new UserEntity{FirstName = "FirstName1", LastName = "LastName", DateOfBirth = DateTime.Parse("01/20/2012",UsCultureInfo.DateTimeFormat)},
-                new UserEntity{FirstName = "FirstName2", LastName = "LastName", DateOfBirth = DateTime.Parse("01/20/2012",UsCultureInfo.DateTimeFormat)},
-                new UserEntity{FirstName = "FirstName3", LastName = "LastName", DateOfBirth = DateTime.Parse("01/20/2012",UsCultureInfo.DateTimeFormat)},
-                new UserEntity{FirstName = "FirstName3", LastName = "LastName", DateOfBirth = DateTime.Parse("03/20/2012",UsCultureInfo.DateTimeFormat)},
-                new UserEntity{FirstName = "FirstName5", LastName = "LastName", DateOfBirth = DateTime.Parse("01/20/2018",UsCultureInfo.DateTimeFormat)},
-            };
+            List<UserEntity> users = CreateUserList();
+
             var mock = users.AsQueryable().BuildMockDbSet();
             var userRepository = new TestDbSetRepository(mock);
             var service = new MyService(userRepository);
@@ -145,14 +133,8 @@ namespace MockQueryable.Sample
         public async Task DbSetGetUserReports(DateTime from, DateTime to, int expectedCount)
         {
             //arrange
-            var users = new List<UserEntity>
-            {
-                new UserEntity{FirstName = "FirstName1", LastName = "LastName", DateOfBirth = DateTime.Parse("01/20/2012",UsCultureInfo.DateTimeFormat)},
-                new UserEntity{FirstName = "FirstName2", LastName = "LastName", DateOfBirth = DateTime.Parse("01/20/2012",UsCultureInfo.DateTimeFormat)},
-                new UserEntity{FirstName = "FirstName3", LastName = "LastName", DateOfBirth = DateTime.Parse("01/20/2012",UsCultureInfo.DateTimeFormat)},
-                new UserEntity{FirstName = "FirstName3", LastName = "LastName", DateOfBirth = DateTime.Parse("03/20/2012",UsCultureInfo.DateTimeFormat)},
-                new UserEntity{FirstName = "FirstName5", LastName = "LastName", DateOfBirth = DateTime.Parse("01/20/2018",UsCultureInfo.DateTimeFormat)},
-            };
+            List<UserEntity> users = CreateUserList();
+
             var mock = users.AsQueryable().BuildMockDbSet();
             var userRepository = new TestDbSetRepository(mock);
             var service = new MyService(userRepository);

--- a/src/MockQueryable/MockQueryable.Sample/MyServiceNSubstituteTests.cs
+++ b/src/MockQueryable/MockQueryable.Sample/MyServiceNSubstituteTests.cs
@@ -1,15 +1,16 @@
-﻿using System;
+﻿using Microsoft.EntityFrameworkCore;
+using MockQueryable.NSubstitute;
+using NSubstitute;
+using NUnit.Framework;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
-using MockQueryable.NSubstitute;
-using NSubstitute;
-using NUnit.Framework;
 
 namespace MockQueryable.Sample
 {
-	[TestFixture]
+    [TestFixture]
     public class MyServiceNSubstituteTests
     {
         private static readonly CultureInfo UsCultureInfo = new CultureInfo("en-US");
@@ -160,6 +161,49 @@ namespace MockQueryable.Sample
             //assert
             Assert.AreEqual(expectedCount, result.Count);
         }
+
+        [TestCase]
+        public async Task DbSetGetAllUserEntitiesAsync()
+        {
+            // arrange
+            List<UserEntity> users = CreateUserList();
+
+            DbSet<UserEntity> mockDbSet = users.AsQueryable().BuildMockDbSet();
+            TestDbSetRepository userRepository = new TestDbSetRepository(mockDbSet);
+
+            // act
+            List<UserEntity> result = await userRepository.GetAllAsync().ToListAsync();
+
+            // assert
+            Assert.AreEqual(users.Count, result.Count);
+        }
+
+        [TestCase]
+        public async Task DbSetGetOneUserTntityAsync()
+        {
+            // arrange
+            List<UserEntity> users = CreateUserList();
+
+            DbSet<UserEntity> mockDbSet = users.AsQueryable().BuildMockDbSet();
+            TestDbSetRepository userRepository = new TestDbSetRepository(mockDbSet);
+
+            // act
+            UserEntity result = await userRepository.GetAllAsync()
+                .Where(user => user.FirstName == "FirstName1")
+                .FirstOrDefaultAsync();
+
+            // assert
+            Assert.AreEqual(users.First(), result);
+        }
+
+        private static List<UserEntity> CreateUserList() => new List<UserEntity>
+        {
+            new UserEntity { FirstName = "FirstName1", LastName = "LastName", DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat) },
+            new UserEntity { FirstName = "FirstName2", LastName = "LastName", DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat) },
+            new UserEntity { FirstName = "FirstName3", LastName = "LastName", DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat) },
+            new UserEntity { FirstName = "FirstName3", LastName = "LastName", DateOfBirth = DateTime.Parse("03/20/2012", UsCultureInfo.DateTimeFormat) },
+            new UserEntity { FirstName = "FirstName5", LastName = "LastName", DateOfBirth = DateTime.Parse("01/20/2018", UsCultureInfo.DateTimeFormat) },
+        };
 
     }
 }

--- a/src/MockQueryable/MockQueryable.Sample/TestDbSetRepository.cs
+++ b/src/MockQueryable/MockQueryable.Sample/TestDbSetRepository.cs
@@ -1,7 +1,7 @@
-﻿using System.Collections.Generic;
+﻿using Microsoft.EntityFrameworkCore;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.EntityFrameworkCore;
 
 namespace MockQueryable.Sample
 {
@@ -25,6 +25,11 @@ namespace MockQueryable.Sample
 
         public List<UserEntity> GetAll() {
             return _dbSet.AsQueryable().ToList();
+        }
+
+        public IAsyncEnumerable<UserEntity> GetAllAsync()
+        {
+            return _dbSet.AsAsyncEnumerable();
         }
     }
 }


### PR DESCRIPTION
# PR Details
* Fix mocking issue for `IAsyncEnumerable` when using NSubstitute

## Description
* Added package `System.Linq.Async` for better testing and real life use case
* Updating NUnit packages to run in latest VS (community) version
* Added new method `ConfigureDbSetCalls` to override result from `.AsQueryable()` and `.AsAsyncEnumerable()` when providing a `DbSet<T>`
* Added private method to return list of users (as mock data) instead of creating new list in most tests

## Related Issue
* This will resolve issue #49 

## How Has This Been Tested
* Written two `NUnit` tests that initially failed. After fix, these two tests now succeed

## Checklist

- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
