### PR TITLE
Added example of how to use without mocking framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ and you want to cover it by unit tests
 
 ### How do I get started?
 
+Just want to provide async queryable data for use with EF Core?
+
 ```csharp
 //1 - create a List<T> with test items
 var users = new List<UserEntity>()
@@ -40,6 +42,22 @@ var users = new List<UserEntity>()
   ...
 };
 
+//2 - build mock by extension
+var mock = users.AsTestAsyncQueryable();
+
+//3 - setup the mock as Queryable for Moq
+_userRepository.Setup(x => x.GetQueryable()).Returns(mock);
+
+//3 - setup the mock as Queryable for NSubstitute
+_userRepository.GetQueryable().Returns(mock);
+
+//3 - setup the mock as Queryable for FakeItEasy
+A.CallTo(() => userRepository.GetQueryable()).Returns(mock);
+```
+
+Want control over mock behavior?
+
+```csharp
 //2 - build mock by extension
 var mock = users.AsQueryable().BuildMock();
 

--- a/src/MockQueryable/MockQueryable.EntityFrameworkCore/EnumerableExtensions.cs
+++ b/src/MockQueryable/MockQueryable.EntityFrameworkCore/EnumerableExtensions.cs
@@ -1,0 +1,13 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace MockQueryable.EntityFrameworkCore
+{
+    public static class EnumerableExtensions
+    {
+        public static IQueryable<T> AsTestAsyncQueryable<T>(this IEnumerable<T> query)
+        {
+            return new TestAsyncEnumerableEfCore<T>(query);
+        }
+    }
+}

--- a/src/MockQueryable/MockQueryable.Sample/MyServiceNoMockTests.cs
+++ b/src/MockQueryable/MockQueryable.Sample/MyServiceNoMockTests.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using MockQueryable.EntityFrameworkCore;
+using Moq;
+using NUnit.Framework;
+
+namespace MockQueryable.Sample
+{
+    [TestFixture]
+    public class MyServiceNoMockTests
+    {
+      private static readonly CultureInfo UsCultureInfo = new CultureInfo("en-US");
+
+      [TestCase("AnyFirstName", "AnyExistLastName", "01/20/2012", "Users with DateOfBirth more than limit")]
+      [TestCase("ExistFirstName", "AnyExistLastName", "02/20/2012", "User with FirstName already exist")]
+      [TestCase("AnyFirstName", "ExistLastName", "01/20/2012", "User already exist")]
+      public void CreateUserIfNotExist(string firstName, string lastName, DateTime dateOfBirth, string expectedError)
+      {
+        //arrange
+        var userRepository = new Mock<IUserRepository>();
+        var service = new MyService(userRepository.Object);
+        var users = new List<UserEntity>
+        {
+          new UserEntity {LastName = "ExistLastName", DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat)},
+          new UserEntity {FirstName = "ExistFirstName"},
+          new UserEntity {DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat)},
+          new UserEntity {DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat)},
+          new UserEntity {DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat)}
+        };
+        //expect
+        var mock = users.AsTestAsyncQueryable();
+        userRepository.Setup(x => x.GetQueryable()).Returns(mock);
+        //act
+        var ex = Assert.ThrowsAsync<ApplicationException>(() =>
+          service.CreateUserIfNotExist(firstName, lastName, dateOfBirth));
+        //assert
+        Assert.AreEqual(expectedError, ex.Message);
+      }
+
+      [TestCase("01/20/2012", "06/20/2018", 5)]
+      [TestCase("01/20/2012", "06/20/2012", 4)]
+      [TestCase("01/20/2012", "02/20/2012", 3)]
+      [TestCase("01/20/2010", "02/20/2011", 0)]
+      public async Task GetUserReports(DateTime from, DateTime to, int expectedCount)
+      {
+        //arrange
+        var userRepository = new Mock<IUserRepository>();
+        var service = new MyService(userRepository.Object);
+        var users = CreateUserList();
+        //expect
+        var mock = users.AsTestAsyncQueryable();
+        userRepository.Setup(x => x.GetQueryable()).Returns(mock);
+        //act
+        var result = await service.GetUserReports(from, to);
+        //assert
+        Assert.AreEqual(expectedCount, result.Count);
+      }
+
+      [TestCase("01/20/2012", "06/20/2018", 5)]
+      [TestCase("01/20/2012", "06/20/2012", 4)]
+      [TestCase("01/20/2012", "02/20/2012", 3)]
+      [TestCase("01/20/2010", "02/20/2011", 0)]
+      public async Task GetUserReports_AutoMap(DateTime from, DateTime to, int expectedCount)
+      {
+        //arrange
+        var userRepository = new Mock<IUserRepository>();
+        var service = new MyService(userRepository.Object);
+        var users = CreateUserList();
+        //expect
+        var mock = users.AsTestAsyncQueryable();
+        userRepository.Setup(x => x.GetQueryable()).Returns(mock);
+        //act
+        var result = await service.GetUserReportsAutoMap(from, to);
+        //assert
+        Assert.AreEqual(expectedCount, result.Count);
+      }
+
+      private static List<UserEntity> CreateUserList() => new List<UserEntity>
+      {
+        new UserEntity { FirstName = "FirstName1", LastName = "LastName", DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat) },
+        new UserEntity { FirstName = "FirstName2", LastName = "LastName", DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat) },
+        new UserEntity { FirstName = "FirstName3", LastName = "LastName", DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat) },
+        new UserEntity { FirstName = "FirstName3", LastName = "LastName", DateOfBirth = DateTime.Parse("03/20/2012", UsCultureInfo.DateTimeFormat) },
+        new UserEntity { FirstName = "FirstName5", LastName = "LastName", DateOfBirth = DateTime.Parse("01/20/2018", UsCultureInfo.DateTimeFormat) },
+      };
+    }
+}


### PR DESCRIPTION
# PR Details

Added extension method for `IEnumerable<T>` that simply returns `new TestAsyncEnumerableEfCore<T>` for the input enumerable.

Using `TestAsyncEnumerableEfCore<T>` directly instead of going through a mocking framework is much faster. See the related issue for benchmark and details. It should behave the same way since all `BuildMock` does is forward interface calls to the underlying `TestAsyncEnumerableEfCore` anyway.

## Related Issue
#55 

## How Has This Been Tested

New test class (`MyServiceNoMockTests`) with tests copied from `MyServiceMoqTests` converted to not use Moq.

## Checklist

- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
