### PR TITLE
Removed generic type constraint in extension methods

### DIFF
--- a/src/MockQueryable/MockQueryable.FakeItEasy/FakeItEasyExtensions.cs
+++ b/src/MockQueryable/MockQueryable.FakeItEasy/FakeItEasyExtensions.cs
@@ -10,7 +10,7 @@ namespace MockQueryable.FakeItEasy
 {
     public static class FakeItEasyExtensions
     {
-        public static IQueryable<TEntity> BuildMock<TEntity>(this IEnumerable<TEntity> data) where TEntity : class
+        public static IQueryable<TEntity> BuildMock<TEntity>(this IEnumerable<TEntity> data)
         {
             return new TestAsyncEnumerableEfCore<TEntity>(data);
         }

--- a/src/MockQueryable/MockQueryable.Moq/MoqExtensions.cs
+++ b/src/MockQueryable/MockQueryable.Moq/MoqExtensions.cs
@@ -10,7 +10,7 @@ namespace MockQueryable.Moq
 {
 	public static class MoqExtensions
 	{
-		public static IQueryable<TEntity> BuildMock<TEntity>(this IEnumerable<TEntity> data) where TEntity : class
+		public static IQueryable<TEntity> BuildMock<TEntity>(this IEnumerable<TEntity> data)
 		{
             return new TestAsyncEnumerableEfCore<TEntity>(data);
 		}

--- a/src/MockQueryable/MockQueryable.NSubstitute/NSubstituteExtensions.cs
+++ b/src/MockQueryable/MockQueryable.NSubstitute/NSubstituteExtensions.cs
@@ -10,7 +10,7 @@ namespace MockQueryable.NSubstitute
 {
   public static class NSubstituteExtensions
   {
-    public static IQueryable<TEntity> BuildMock<TEntity>(this IEnumerable<TEntity> data) where TEntity : class
+    public static IQueryable<TEntity> BuildMock<TEntity>(this IEnumerable<TEntity> data)
     {
         return new TestAsyncEnumerableEfCore<TEntity>(data);
     }


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

- Allows `TEntity` to be a value type.

The extension methods had a [generic type constraint](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/where-generic-type-constraint) that prevented `IQueryable<T>` where `T` is a value type from being mocked.

> I wasn't sure if the **reference type** constraint was intentional, an oversight, or leftover from older code.  I successfully used the following locally to work around it and figured other could benefit:
> 
> ```csharp
> var data = new TestAsyncEnumerableEfCore<long>(new[] { 42L });
> ```

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- see how your change affects other areas of the code, etc. -->

- All existing tests passed.
- Locally used the code called by the extension method and it worked with a `long` for `TEntity`.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [ ] ~~I have added tests to cover my changes.~~
  > All tests passed.  Hopefully covered by existing test suite...but I'll check that!  Maybe we should make a value type test. ;)
- [X] All new and existing tests passed.
