### PR TITLE
Fix ToListAsync() for mocked DbSet by using lazy-creation of AsyncEnumerator

### DIFF
--- a/src/MockQueryable/MockQueryable.FakeItEasy/FakeItEasyExtensions.cs
+++ b/src/MockQueryable/MockQueryable.FakeItEasy/FakeItEasyExtensions.cs
@@ -24,7 +24,7 @@ namespace MockQueryable.FakeItEasy
             mock.ConfigureDbSetCalls(data);
             if (mock is IAsyncEnumerable<TEntity> asyncEnumerable)
             {
-                A.CallTo(() => asyncEnumerable.GetAsyncEnumerator(A<CancellationToken>.Ignored)).Returns(enumerable.GetAsyncEnumerator());
+                A.CallTo(() => asyncEnumerable.GetAsyncEnumerator(A<CancellationToken>.Ignored)).ReturnsLazily(() => enumerable.GetAsyncEnumerator());
             }
             return mock;
         }

--- a/src/MockQueryable/MockQueryable.Moq/MoqExtensions.cs
+++ b/src/MockQueryable/MockQueryable.Moq/MoqExtensions.cs
@@ -21,7 +21,7 @@ namespace MockQueryable.Moq
 			var enumerable = new TestAsyncEnumerableEfCore<TEntity>(data);
 			mock.ConfigureAsyncEnumerableCalls(enumerable);
 			mock.As<IQueryable<TEntity>>().ConfigureQueryableCalls(enumerable, data);
-            mock.As<IAsyncEnumerable<TEntity>>().Setup(x => x.GetAsyncEnumerator(It.IsAny<CancellationToken>())).Returns(enumerable.GetAsyncEnumerator());
+            mock.As<IAsyncEnumerable<TEntity>>().Setup(x => x.GetAsyncEnumerator(It.IsAny<CancellationToken>())).Returns(() => enumerable.GetAsyncEnumerator());
 			mock.Setup(m => m.AsQueryable()).Returns(enumerable);
 
 			mock.ConfigureDbSetCalls(data);

--- a/src/MockQueryable/MockQueryable.Sample/MyServiceFakeItEasyTests.cs
+++ b/src/MockQueryable/MockQueryable.Sample/MyServiceFakeItEasyTests.cs
@@ -166,6 +166,25 @@ namespace MockQueryable.Sample
     }
 
     [TestCase]
+    public async Task DbSetGetAllUserEntitiesAsync_ShouldReturnAllEntities_WhenSourceIsChanged()
+    {
+      // arrange
+      var users = new List<UserEntity>();
+
+      var mockDbSet = users.AsQueryable().BuildMockDbSet();
+      var userRepository = new TestDbSetRepository(mockDbSet);
+
+      // act
+      var result1 = await userRepository.GetAllAsync().ToListAsync();
+      users.AddRange(CreateUserList());
+      var result2 = await userRepository.GetAllAsync().ToListAsync();
+
+      // assert
+      Assert.AreEqual(0, result1.Count);
+      Assert.AreEqual(users.Count, result2.Count);
+    }
+
+    [TestCase]
     public async Task DbSetGetAllUserEntity()
     {
         //arrange

--- a/src/MockQueryable/MockQueryable.Sample/MyServiceFakeItEasyTests.cs
+++ b/src/MockQueryable/MockQueryable.Sample/MyServiceFakeItEasyTests.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using FakeItEasy;
+using Microsoft.EntityFrameworkCore;
 using MockQueryable.FakeItEasy;
 using NUnit.Framework;
 
@@ -166,18 +167,17 @@ namespace MockQueryable.Sample
     }
 
     [TestCase]
-    public async Task DbSetGetAllUserEntitiesAsync_ShouldReturnAllEntities_WhenSourceIsChanged()
+    public async Task DbSetToListAsyncAsync_ShouldReturnAllEntities_WhenSourceIsChanged()
     {
       // arrange
       var users = new List<UserEntity>();
 
       var mockDbSet = users.AsQueryable().BuildMockDbSet();
-      var userRepository = new TestDbSetRepository(mockDbSet);
-
+      
       // act
-      var result1 = await userRepository.GetAllAsync().ToListAsync();
+      var result1 = await mockDbSet.ToListAsync();
       users.AddRange(CreateUserList());
-      var result2 = await userRepository.GetAllAsync().ToListAsync();
+      var result2 = await mockDbSet.ToListAsync();
 
       // assert
       Assert.AreEqual(0, result1.Count);

--- a/src/MockQueryable/MockQueryable.Sample/MyServiceMoqTests.cs
+++ b/src/MockQueryable/MockQueryable.Sample/MyServiceMoqTests.cs
@@ -233,18 +233,17 @@ namespace MockQueryable.Sample
     
     
     [TestCase]
-    public async Task DbSetGetAllUserEntitiesAsync_ShouldReturnAllEntities_WhenSourceIsChanged()
+    public async Task DbSetToListAsyncAsync_ShouldReturnAllEntities_WhenSourceIsChanged()
     {
       // arrange
       var users = new List<UserEntity>();
 
       var mockDbSet = users.AsQueryable().BuildMockDbSet();
-      var userRepository = new TestDbSetRepository(mockDbSet.Object);
 
       // act
-      var result1 = await userRepository.GetAllAsync().ToListAsync();
+      var result1 = await mockDbSet.Object.ToListAsync();
       users.AddRange(CreateUserList());
-      var result2 = await userRepository.GetAllAsync().ToListAsync();
+      var result2 = await mockDbSet.Object.ToListAsync();
 
       // assert
       Assert.AreEqual(0, result1.Count);

--- a/src/MockQueryable/MockQueryable.Sample/MyServiceMoqTests.cs
+++ b/src/MockQueryable/MockQueryable.Sample/MyServiceMoqTests.cs
@@ -230,6 +230,28 @@ namespace MockQueryable.Sample
       // assert
       Assert.AreEqual(users.Count, result.Count);
     }
+    
+    
+    [TestCase]
+    public async Task DbSetGetAllUserEntitiesAsync_ShouldReturnAllEntities_WhenSourceIsChanged()
+    {
+      // arrange
+      var users = new List<UserEntity>();
+
+      var mockDbSet = users.AsQueryable().BuildMockDbSet();
+      var userRepository = new TestDbSetRepository(mockDbSet.Object);
+
+      // act
+      var result1 = await userRepository.GetAllAsync().ToListAsync();
+      users.AddRange(CreateUserList());
+      var result2 = await userRepository.GetAllAsync().ToListAsync();
+
+      // assert
+      Assert.AreEqual(0, result1.Count);
+      Assert.AreEqual(users.Count, result2.Count);
+    }
+
+
 
     private static List<UserEntity> CreateUserList() => new List<UserEntity>
     {

--- a/src/MockQueryable/MockQueryable.Sample/MyServiceNSubstituteTests.cs
+++ b/src/MockQueryable/MockQueryable.Sample/MyServiceNSubstituteTests.cs
@@ -172,6 +172,26 @@ namespace MockQueryable.Sample
             // assert
             Assert.AreEqual(users.Count, result.Count);
         }
+        
+        
+        [TestCase]
+        public async Task DbSetGetAllUserEntitiesAsync_ShouldReturnAllEntities_WhenSourceIsChanged()
+        {
+	        // arrange
+	        var users = new List<UserEntity>();
+
+	        var mockDbSet = users.AsQueryable().BuildMockDbSet();
+	        var userRepository = new TestDbSetRepository(mockDbSet);
+
+	        // act
+	        var result1 = await userRepository.GetAllAsync().ToListAsync();
+	        users.AddRange(CreateUserList());
+	        var result2 = await userRepository.GetAllAsync().ToListAsync();
+
+	        // assert
+	        Assert.AreEqual(0, result1.Count);
+	        Assert.AreEqual(users.Count, result2.Count);
+        }
 
         [TestCase]
         public async Task DbSetGetOneUserTntityAsync()


### PR DESCRIPTION
# PR Details

This PR fixes ToListAsync() for mocked DbSets.

## Description

In the original implementation, GetAsyncEnumerator() in BuildMockDbSet() was setup to return the current result of enumerable.GetAsyncEnumerator(). This leads to multiple issues when using ToListAsync():

- Only the initial state of the enumerable may be yielded.
- Iteration may fail with an InvalidOperationException "Collection was modified" when the collection is updated.

This fix applies only for Moq and FakeItEasy, as the NSubsitute version already used lazy returns.

## Related Issue

## How Has This Been Tested

- Created new test cases.
- Tested against my productive code after building the nuget package

## Checklist

- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
