### PR TITLE
Added method for build DbSet from IEnumerable.

### DIFF
--- a/src/MockQueryable/MockQueryable.FakeItEasy/FakeItEasyExtensions.cs
+++ b/src/MockQueryable/MockQueryable.FakeItEasy/FakeItEasyExtensions.cs
@@ -15,6 +15,8 @@ namespace MockQueryable.FakeItEasy
             return new TestAsyncEnumerableEfCore<TEntity>(data);
         }
 
+        public static DbSet<TEntity> BuildMockDbSet<TEntity>(this IEnumerable<TEntity> data) where TEntity : class => data.BuildMock().BuildMockDbSet();
+
         public static DbSet<TEntity> BuildMockDbSet<TEntity>(this IQueryable<TEntity> data) where TEntity : class
         {
             var mock = A.Fake<DbSet<TEntity>>(d => d.Implements<IAsyncEnumerable<TEntity>>().Implements<IQueryable<TEntity>>());

--- a/src/MockQueryable/MockQueryable.Moq/MoqExtensions.cs
+++ b/src/MockQueryable/MockQueryable.Moq/MoqExtensions.cs
@@ -10,10 +10,12 @@ namespace MockQueryable.Moq
 {
 	public static class MoqExtensions
 	{
-		public static IQueryable<TEntity> BuildMock<TEntity>(this IEnumerable<TEntity> data) where TEntity : class
+        public static IQueryable<TEntity> BuildMock<TEntity>(this IEnumerable<TEntity> data) where TEntity : class
 		{
             return new TestAsyncEnumerableEfCore<TEntity>(data);
 		}
+
+		public static Mock<DbSet<TEntity>> BuildMockDbSet<TEntity>(this IEnumerable<TEntity> data) where TEntity : class => data.BuildMock().BuildMockDbSet();
 
 		public static Mock<DbSet<TEntity>> BuildMockDbSet<TEntity>(this IQueryable<TEntity> data) where TEntity : class
 		{

--- a/src/MockQueryable/MockQueryable.NSubstitute/NSubstituteExtensions.cs
+++ b/src/MockQueryable/MockQueryable.NSubstitute/NSubstituteExtensions.cs
@@ -15,6 +15,8 @@ namespace MockQueryable.NSubstitute
         return new TestAsyncEnumerableEfCore<TEntity>(data);
     }
 
+    public static DbSet<TEntity> BuildMockDbSet<TEntity>(this IEnumerable<TEntity> data) where TEntity : class => data.BuildMock().BuildMockDbSet();
+
     public static DbSet<TEntity> BuildMockDbSet<TEntity>(this IQueryable<TEntity> data) where TEntity : class
     {
       var mock = Substitute.For<DbSet<TEntity>, IQueryable<TEntity>, IAsyncEnumerable<TEntity>>();

--- a/src/MockQueryable/MockQueryable.Sample/MyServiceMoqTests.cs
+++ b/src/MockQueryable/MockQueryable.Sample/MyServiceMoqTests.cs
@@ -110,7 +110,31 @@ namespace MockQueryable.Sample
       Assert.AreEqual(expectedError, ex.Message);
     }
 
-    [TestCase("AnyFirstName", "ExistLastName", "01/20/2012")]
+    [TestCase("AnyFirstName", "AnyExistLastName", "01/20/2012", "Users with DateOfBirth more than limit")]
+    [TestCase("ExistFirstName", "AnyExistLastName", "02/20/2012", "User with FirstName already exist")]
+    [TestCase("AnyFirstName", "ExistLastName", "01/20/2012", "User already exist")]
+    public void DbSetCreatedFromCollectionCreateUserIfNotExist(string firstName, string lastName, DateTime dateOfBirth, string expectedError)
+    {
+        //arrange
+        var users = new List<UserEntity>
+        {
+            new UserEntity {LastName = "ExistLastName", DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat)},
+            new UserEntity {FirstName = "ExistFirstName"},
+            new UserEntity {DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat)},
+            new UserEntity {DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat)},
+            new UserEntity {DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat)}
+        };
+        var mock = users.BuildMockDbSet();
+        var userRepository = new TestDbSetRepository(mock.Object);
+        var service = new MyService(userRepository);
+        //act
+        var ex = Assert.ThrowsAsync<ApplicationException>(() =>
+                                                              service.CreateUserIfNotExist(firstName, lastName, dateOfBirth));
+        //assert
+        Assert.AreEqual(expectedError, ex.Message);
+    }
+
+        [TestCase("AnyFirstName", "ExistLastName", "01/20/2012")]
     public async Task DbSetCreateUser(string firstName, string lastName, DateTime dateOfBirth)
     {
       //arrange
@@ -130,7 +154,27 @@ namespace MockQueryable.Sample
       Assert.AreEqual(dateOfBirth, entity.DateOfBirth);
     }
 
-    [TestCase("01/20/2012", "06/20/2018", 5)]
+    [TestCase("AnyFirstName", "ExistLastName", "01/20/2012")]
+    public async Task DbSetCreatedFromCollectionCreateUser(string firstName, string lastName, DateTime dateOfBirth)
+    {
+        //arrange
+        var userEntities = new List<UserEntity>();
+        var mock = userEntities.BuildMockDbSet();
+
+        mock.Setup(set => set.AddAsync(It.IsAny<UserEntity>(), It.IsAny<CancellationToken>()))
+            .Callback((UserEntity entity, CancellationToken _) => userEntities.Add(entity));
+        var userRepository = new TestDbSetRepository(mock.Object);
+        var service = new MyService(userRepository);
+        //act
+        await service.CreateUserIfNotExist(firstName, lastName, dateOfBirth);
+        // assert
+        var entity = mock.Object.Single();
+        Assert.AreEqual(firstName, entity.FirstName);
+        Assert.AreEqual(lastName, entity.LastName);
+        Assert.AreEqual(dateOfBirth, entity.DateOfBirth);
+    }
+
+        [TestCase("01/20/2012", "06/20/2018", 5)]
     [TestCase("01/20/2012", "06/20/2012", 4)]
     [TestCase("01/20/2012", "02/20/2012", 3)]
     [TestCase("01/20/2010", "02/20/2011", 0)]
@@ -147,7 +191,24 @@ namespace MockQueryable.Sample
       Assert.AreEqual(expectedCount, result.Count);
     }
 
-    [TestCase]
+    [TestCase("01/20/2012", "06/20/2018", 5)]
+    [TestCase("01/20/2012", "06/20/2012", 4)]
+    [TestCase("01/20/2012", "02/20/2012", 3)]
+    [TestCase("01/20/2010", "02/20/2011", 0)]
+    public async Task DbSetCreatedFromCollectionGetUserReports(DateTime from, DateTime to, int expectedCount)
+    {
+        //arrange
+        var users = CreateUserList();
+        var mock = users.BuildMockDbSet();
+        var userRepository = new TestDbSetRepository(mock.Object);
+        var service = new MyService(userRepository);
+        //act
+        var result = await service.GetUserReports(from, to);
+        //assert
+        Assert.AreEqual(expectedCount, result.Count);
+    }
+
+        [TestCase]
     public async Task DbSetGetAllUserEntity()
     {
       //arrange
@@ -161,6 +222,19 @@ namespace MockQueryable.Sample
     }
 
     [TestCase]
+    public async Task DbSetCreatedFromCollectionGetAllUserEntity()
+    {
+        //arrange
+        var users = CreateUserList();
+        var mock = users.BuildMockDbSet();
+        var userRepository = new TestDbSetRepository(mock.Object);
+        //act
+        var result = await userRepository.GetAll();
+        //assert
+        Assert.AreEqual(users.Count, result.Count);
+    }
+
+        [TestCase]
     public async Task DbSetFindAsyncUserEntity()
     {
       //arrange
@@ -215,7 +289,63 @@ namespace MockQueryable.Sample
       Assert.AreEqual("FirstName3", result.FirstName);
     }
 
+
     [TestCase]
+    public async Task DbSetCreatedFromCollectionFindAsyncUserEntity()
+    {
+        //arrange
+        var userId = Guid.NewGuid();
+        var users = new List<UserEntity>
+        {
+            new UserEntity
+            {
+                Id = Guid.NewGuid(),
+                FirstName = "FirstName1", LastName = "LastName",
+                DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat)
+            },
+            new UserEntity
+            {
+                Id = Guid.NewGuid(),
+                FirstName = "FirstName2", LastName = "LastName",
+                DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat)
+            },
+            new UserEntity
+            {
+                Id = userId,
+                FirstName = "FirstName3", LastName = "LastName",
+                DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat)
+            },
+            new UserEntity
+            {
+                Id = Guid.NewGuid(),
+                FirstName = "FirstName3", LastName = "LastName",
+                DateOfBirth = DateTime.Parse("03/20/2012", UsCultureInfo.DateTimeFormat)
+            },
+            new UserEntity
+            {
+                Id = Guid.NewGuid(),
+                FirstName = "FirstName5", LastName = "LastName",
+                DateOfBirth = DateTime.Parse("01/20/2018", UsCultureInfo.DateTimeFormat)
+            }
+        };
+
+        var mock = users.BuildMockDbSet();
+        mock.Setup(x => x.FindAsync(It.IsAny<object[]>())).ReturnsAsync((object[] ids) =>
+        {
+            var id = (Guid)ids.First();
+            return users.FirstOrDefault(x => x.Id == id);
+        });
+        var userRepository = new TestDbSetRepository(mock.Object);
+
+        //act
+        var result = await ((DbSet<UserEntity>)userRepository.GetQueryable()).FindAsync(userId);
+
+        //assert
+        Assert.IsNotNull(result);
+        Assert.AreEqual("FirstName3", result.FirstName);
+    }
+
+        [TestCase]
     public async Task DbSetGetAllUserEntitiesAsync()
     {
       // arrange
@@ -231,7 +361,23 @@ namespace MockQueryable.Sample
       Assert.AreEqual(users.Count, result.Count);
     }
 
-    private static List<UserEntity> CreateUserList() => new List<UserEntity>
+    [TestCase]
+    public async Task DbSetCreatedFromCollectionGetAllUserEntitiesAsync()
+    {
+        // arrange
+        var users = CreateUserList();
+
+        var mockDbSet = users.BuildMockDbSet();
+        var userRepository = new TestDbSetRepository(mockDbSet.Object);
+
+        // act
+        var result = await userRepository.GetAllAsync().ToListAsync();
+
+        // assert
+        Assert.AreEqual(users.Count, result.Count);
+    }
+
+        private static List<UserEntity> CreateUserList() => new List<UserEntity>
     {
       new UserEntity { FirstName = "FirstName1", LastName = "LastName", DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat) },
       new UserEntity { FirstName = "FirstName2", LastName = "LastName", DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat) },

--- a/src/MockQueryable/MockQueryable.Sample/MyServiceNSubstituteTests.cs
+++ b/src/MockQueryable/MockQueryable.Sample/MyServiceNSubstituteTests.cs
@@ -80,6 +80,25 @@ namespace MockQueryable.Sample
 
         }
 
+        [TestCase("01/20/2012", "06/20/2018", 5)]
+        [TestCase("01/20/2012", "06/20/2012", 4)]
+        [TestCase("01/20/2012", "02/20/2012", 3)]
+        [TestCase("01/20/2010", "02/20/2011", 0)]
+        public async Task GetUserReports_AutoMap_FromDbSetCreatedFromCollection(DateTime from, DateTime to, int expectedCount)
+        {
+            //arrange
+            List<UserEntity> users = CreateUserList();
+
+            var mock = users.BuildMockDbSet();
+            var userRepository = new TestDbSetRepository(mock);
+            var service = new MyService(userRepository);
+            //act
+            var result = await service.GetUserReportsAutoMap(from, to);
+            //assert
+            Assert.AreEqual(expectedCount, result.Count);
+
+        }
+
         [TestCase("AnyFirstName", "AnyExistLastName", "01/20/2012", "Users with DateOfBirth more than limit")]
         [TestCase("ExistFirstName", "AnyExistLastName", "02/20/2012", "User with FirstName already exist")]
         [TestCase("AnyFirstName", "ExistLastName", "01/20/2012", "User already exist")]
@@ -105,12 +124,56 @@ namespace MockQueryable.Sample
         }
 
 
+        [TestCase("AnyFirstName", "AnyExistLastName", "01/20/2012", "Users with DateOfBirth more than limit")]
+        [TestCase("ExistFirstName", "AnyExistLastName", "02/20/2012", "User with FirstName already exist")]
+        [TestCase("AnyFirstName", "ExistLastName", "01/20/2012", "User already exist")]
+        public void DbSetCreatedFromCollectionCreateUserIfNotExist(string firstName, string lastName, DateTime dateOfBirth, string expectedError)
+        {
+            //arrange
+            var users = new List<UserEntity>
+            {
+                new UserEntity{LastName = "ExistLastName", DateOfBirth = DateTime.Parse("01/20/2012",UsCultureInfo.DateTimeFormat)},
+                new UserEntity{FirstName = "ExistFirstName"},
+                new UserEntity{DateOfBirth = DateTime.Parse("01/20/2012",UsCultureInfo.DateTimeFormat)},
+                new UserEntity{DateOfBirth = DateTime.Parse("01/20/2012",UsCultureInfo.DateTimeFormat)},
+                new UserEntity{DateOfBirth = DateTime.Parse("01/20/2012",UsCultureInfo.DateTimeFormat)},
+            };
+            var mock = users.BuildMockDbSet();
+            var userRepository = new TestDbSetRepository(mock);
+            var service = new MyService(userRepository);
+            //act
+            var ex = Assert.ThrowsAsync<ApplicationException>(() => service.CreateUserIfNotExist(firstName, lastName, dateOfBirth));
+            //assert
+            Assert.AreEqual(expectedError, ex.Message);
+
+        }
+
         [TestCase("AnyFirstName", "ExistLastName", "01/20/2012")]
         public async Task DbSetCreateUser(string firstName, string lastName, DateTime dateOfBirth)
         {
             //arrange
             var userEntities = new List<UserEntity>();
             var mock = userEntities.AsQueryable().BuildMockDbSet();
+            mock.AddAsync(Arg.Any<UserEntity>())
+                .Returns(info => null)
+                .AndDoes(info => userEntities.Add(info.Arg<UserEntity>()));
+            var userRepository = new TestDbSetRepository(mock);
+            var service = new MyService(userRepository);
+            //act
+            await service.CreateUserIfNotExist(firstName, lastName, dateOfBirth);
+            // assert
+            var entity = mock.Single();
+            Assert.AreEqual(firstName, entity.FirstName);
+            Assert.AreEqual(lastName, entity.LastName);
+            Assert.AreEqual(dateOfBirth, entity.DateOfBirth);
+        }
+
+        [TestCase("AnyFirstName", "ExistLastName", "01/20/2012")]
+        public async Task DbSetCreatedFromCollectionCreateUser(string firstName, string lastName, DateTime dateOfBirth)
+        {
+            //arrange
+            var userEntities = new List<UserEntity>();
+            var mock = userEntities.BuildMockDbSet();
             mock.AddAsync(Arg.Any<UserEntity>())
                 .Returns(info => null)
                 .AndDoes(info => userEntities.Add(info.Arg<UserEntity>()));
@@ -143,6 +206,23 @@ namespace MockQueryable.Sample
             Assert.AreEqual(expectedCount, result.Count);
         }
 
+        [TestCase("01/20/2012", "06/20/2018", 5)]
+        [TestCase("01/20/2012", "06/20/2012", 4)]
+        [TestCase("01/20/2012", "02/20/2012", 3)]
+        [TestCase("01/20/2010", "02/20/2011", 0)]
+        public async Task DbSetCreatedFromCollectionGetUserReports(DateTime from, DateTime to, int expectedCount)
+        {
+            //arrange
+            var users = CreateUserList();
+
+            var mock = users.BuildMockDbSet();
+            var userRepository = new TestDbSetRepository(mock);
+            var service = new MyService(userRepository);
+            //act
+            var result = await service.GetUserReports(from, to);
+            //assert
+            Assert.AreEqual(expectedCount, result.Count);
+        }
 
         [TestCase]
         public async Task DbSetGetAllUserEntity()
@@ -150,6 +230,19 @@ namespace MockQueryable.Sample
             //arrange
             var users = CreateUserList();
             var mock = users.AsQueryable().BuildMockDbSet();
+            var userRepository = new TestDbSetRepository(mock);
+            //act
+            var result = await userRepository.GetAll();
+            //assert
+            Assert.AreEqual(users.Count, result.Count);
+        }
+
+        [TestCase]
+        public async Task DbSetCreatedFromCollectionGetAllUserEntity()
+        {
+            //arrange
+            var users = CreateUserList();
+            var mock = users.BuildMockDbSet();
             var userRepository = new TestDbSetRepository(mock);
             //act
             var result = await userRepository.GetAll();
@@ -174,6 +267,22 @@ namespace MockQueryable.Sample
         }
 
         [TestCase]
+        public async Task DbSetCreatedFromCollectionGetAllUserEntitiesAsync()
+        {
+            // arrange
+            var users = CreateUserList();
+
+            var mockDbSet = users.BuildMockDbSet();
+            var userRepository = new TestDbSetRepository(mockDbSet);
+
+            // act
+            var result = await userRepository.GetAllAsync().ToListAsync();
+
+            // assert
+            Assert.AreEqual(users.Count, result.Count);
+        }
+
+        [TestCase]
         public async Task DbSetGetOneUserTntityAsync()
         {
             // arrange
@@ -186,6 +295,24 @@ namespace MockQueryable.Sample
             var result = await userRepository.GetAllAsync()
                 .Where(user => user.FirstName == "FirstName1")
                 .FirstOrDefaultAsync();
+
+            // assert
+            Assert.AreEqual(users.First(), result);
+        }
+
+        [TestCase]
+        public async Task DbSetCreatedFromCollectionGetOneUserTntityAsync()
+        {
+            // arrange
+            var users = CreateUserList();
+
+            var mockDbSet = users.BuildMockDbSet();
+            var userRepository = new TestDbSetRepository(mockDbSet);
+
+            // act
+            var result = await userRepository.GetAllAsync()
+                                             .Where(user => user.FirstName == "FirstName1")
+                                             .FirstOrDefaultAsync();
 
             // assert
             Assert.AreEqual(users.First(), result);


### PR DESCRIPTION
# PR Details

Added a method that allows you to create a `DbSet<T>` from an `IEnumerable<T>`.

## Description

Often, when performing testing, to create a `DbSet<T>` from a collection, it was necessary to call the `AsQueryable()` then `BuildMockDbSet()` methods. For example: 

`
var users = new List<User>();`<br>`
DbSet<User> dbSet = users.AsQueryable().BuildMockDbSet();
`

This improvement allows you to create a  `DbSet<T>` right away. For example: 

`
var users = new List<User>();`<br>`
DbSet<User> dbSet = users.BuildMockDbSet();
`