### PR TITLE
Altered namespace for extension method to revert a breaking change wi…

### DIFF
--- a/src/MockQueryable/MockQueryable.EntityFrameworkCore/MockQueryableExtensions.cs
+++ b/src/MockQueryable/MockQueryable.EntityFrameworkCore/MockQueryableExtensions.cs
@@ -1,14 +1,19 @@
-﻿using System.Collections.Generic;
+﻿using MockQueryable.EntityFrameworkCore;
+using System.Collections.Generic;
 using System.Linq;
 
-
-namespace MockQueryable.EntityFrameworkCore
+// Moving MockQueryableExtensions BuildMock into the MockQueryable.EntityFrameworkCore
+// namespace had breaking changes with earlier extensions added to MockQueryable.Moq
+// and other previous extension method locations. Moving this extension up a namespace to
+// MockQueryable aleviates that breaking change. It still needs to remain in EF core since it
+// is dependent on the EF Core AsyncEnumerable.
+namespace MockQueryable
 {
     public static class MockQueryableExtensions
     {
         public static IQueryable<TEntity> BuildMock<TEntity>(this IEnumerable<TEntity> data) where TEntity : class
-		{
+        {
             return new TestAsyncEnumerableEfCore<TEntity>(data);
-		}
+        }
     }
 }


### PR DESCRIPTION
…th previous extension methods that were consolidated here.

# PR Details

I updated the namespace for the extension method. Previously developers would have used one of several extension methods that were consolidated under the EFCore namespace, causing a breaking change. By moving it up those namespaces will still resolve.

## Description

see above.

## Related Issue

https://github.com/romantitov/MockQueryable/issues/79

## How Has This Been Tested

Re-ran existing unit tests after changing the namespace. Extension is under the root MockQueryable namespace.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
