### PR TITLE
Add support to ExecuteDelete and ExecuteUpdate

### DIFF
--- a/src/MockQueryable/MockQueryable.Core/TestQueryProvider.cs
+++ b/src/MockQueryable/MockQueryable.Core/TestQueryProvider.cs
@@ -6,78 +6,92 @@ using System.Linq.Expressions;
 
 namespace MockQueryable.Core
 {
-	public abstract class TestQueryProvider<T> : IOrderedQueryable<T>, IQueryProvider
-	{
-		private IEnumerable<T> _enumerable;
-
-    protected TestQueryProvider(Expression expression)
-		{
-			Expression = expression;
-		}
-
-    protected TestQueryProvider(IEnumerable<T> enumerable)
-		{
-			_enumerable = enumerable;
-      Expression = enumerable.AsQueryable().Expression;
-		}
-
-		public IQueryable CreateQuery(Expression expression)
-		{
-			if (expression is MethodCallExpression m)
-			{
-				var resultType = m.Method.ReturnType; // it should be IQueryable<T>
-				var tElement = resultType.GetGenericArguments().First();
-				return (IQueryable) CreateInstance(tElement, expression);
-			}
-
-      return CreateQuery<T>(expression);
-		}
-
-		public IQueryable<TEntity> CreateQuery<TEntity>(Expression expression)
-		{
-      return (IQueryable<TEntity>) CreateInstance(typeof(TEntity), expression);
-    }
-
-    private object CreateInstance(Type tElement, Expression expression)
+    public abstract class TestQueryProvider<T> : IOrderedQueryable<T>, IQueryProvider
     {
-      var queryType = GetType().GetGenericTypeDefinition().MakeGenericType(tElement);
-      return Activator.CreateInstance(queryType, expression);
-		}
+        // Hardcoding this constants to avoid the reference to EFCore
+        private const string EF_EXECUTE_UPDATE_METHOD_NAME = "ExecuteUpdate";
+        private const string EF_EXECUTE_DELETE_METHOD_NAME = "ExecuteDelete";
 
-		public object Execute(Expression expression)
-		{
-			return CompileExpressionItem<object>(expression);
-		}
+        private IEnumerable<T> _enumerable;
 
-		public TResult Execute<TResult>(Expression expression)
-		{
-			return CompileExpressionItem<TResult>(expression);
-		}
+        protected TestQueryProvider(Expression expression)
+        {
+            Expression = expression;
+        }
 
-		IEnumerator<T> IEnumerable<T>.GetEnumerator()
-		{
-			if (_enumerable == null) _enumerable = CompileExpressionItem<IEnumerable<T>>(Expression);
-			return _enumerable.GetEnumerator();
-		}
+        protected TestQueryProvider(IEnumerable<T> enumerable)
+        {
+            _enumerable = enumerable;
+            Expression = enumerable.AsQueryable().Expression;
+        }
 
-		IEnumerator IEnumerable.GetEnumerator()
-		{
-			if (_enumerable == null) _enumerable = CompileExpressionItem<IEnumerable<T>>(Expression);
-			return _enumerable.GetEnumerator();
-		}
+        public IQueryable CreateQuery(Expression expression)
+        {
+            if (expression is MethodCallExpression m)
+            {
+                var resultType = m.Method.ReturnType; // it should be IQueryable<T>
+                var tElement = resultType.GetGenericArguments().First();
+                return (IQueryable) CreateInstance(tElement, expression);
+            }
 
-		public Type ElementType => typeof(T);
+            return CreateQuery<T>(expression);
+        }
 
-		public Expression Expression { get; }
+        public IQueryable<TEntity> CreateQuery<TEntity>(Expression expression)
+        {
+            return (IQueryable<TEntity>) CreateInstance(typeof(TEntity), expression);
+        }
 
-		public IQueryProvider Provider => this;
+        private object CreateInstance(Type tElement, Expression expression)
+        {
+            var queryType = GetType().GetGenericTypeDefinition().MakeGenericType(tElement);
+            return Activator.CreateInstance(queryType, expression);
+        }
 
-		private static TResult CompileExpressionItem<TResult>(Expression expression)
-		{
-			var visitor = new TestExpressionVisitor();
-			var body = visitor.Visit(expression);
-			var f = Expression.Lambda<Func<TResult>>(body ?? throw new InvalidOperationException($"{nameof(body)} is null"), (IEnumerable<ParameterExpression>) null);
-			return f.Compile()();
-		}
-	}
+        public object Execute(Expression expression)
+        {
+            return CompileExpressionItem<object>(expression);
+        }
+
+        public TResult Execute<TResult>(Expression expression)
+        {
+            if (expression is MethodCallExpression methodCall && (methodCall.Method.Name == EF_EXECUTE_UPDATE_METHOD_NAME || methodCall.Method.Name == EF_EXECUTE_DELETE_METHOD_NAME)
+                && typeof(TResult) == typeof(int))
+            {
+                // Intercept ExecuteDelete and ExecuteUpdate calls
+                var affectedItems = CompileExpressionItem<IEnumerable<T>>(Expression).ToList();
+                // Return the count of affected items
+                return (TResult)(object)affectedItems.Count;
+            }
+
+            // Fall back to default expression execution
+            return CompileExpressionItem<TResult>(expression);
+        }
+
+        IEnumerator<T> IEnumerable<T>.GetEnumerator()
+        {
+            if (_enumerable == null) _enumerable = CompileExpressionItem<IEnumerable<T>>(Expression);
+            return _enumerable.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            if (_enumerable == null) _enumerable = CompileExpressionItem<IEnumerable<T>>(Expression);
+            return _enumerable.GetEnumerator();
+        }
+
+        public Type ElementType => typeof(T);
+
+        public Expression Expression { get; }
+
+        public IQueryProvider Provider => this;
+
+        private static TResult CompileExpressionItem<TResult>(Expression expression)
+        {
+            var visitor = new TestExpressionVisitor();
+            var body = visitor.Visit(expression);
+            var f = Expression.Lambda<Func<TResult>>(body ?? throw new InvalidOperationException($"{nameof(body)} is null"), (IEnumerable<ParameterExpression>) null);
+            return f.Compile()();
+        }
+    }
 }

--- a/src/MockQueryable/MockQueryable.EntityFrameworkCore/MockQueryable.EntityFrameworkCore.csproj
+++ b/src/MockQueryable/MockQueryable.EntityFrameworkCore/MockQueryable.EntityFrameworkCore.csproj
@@ -45,7 +45,7 @@
 		</None>
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.0" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.20" />
 	</ItemGroup>
 
   <ItemGroup>

--- a/src/MockQueryable/MockQueryable.Sample/MockQueryable.Sample.csproj
+++ b/src/MockQueryable/MockQueryable.Sample/MockQueryable.Sample.csproj
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="7.0.20" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1">

--- a/src/MockQueryable/MockQueryable.Sample/MyService.cs
+++ b/src/MockQueryable/MockQueryable.Sample/MyService.cs
@@ -1,108 +1,111 @@
-﻿using System;
+﻿using AutoMapper;
+using AutoMapper.QueryableExtensions;
+using Microsoft.EntityFrameworkCore;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using AutoMapper;
-using AutoMapper.QueryableExtensions;
-using Microsoft.EntityFrameworkCore;
 
 namespace MockQueryable.Sample
 {
-  public class MyService
-  {
-    private readonly IUserRepository _userRepository;
-
-    public static void Initialize()
+    public class MyService
     {
-      Mapper.Initialize(cfg => cfg.CreateMap<UserEntity, UserReport>()
-        .ForMember(dto => dto.FirstName, conf => conf.MapFrom(ol => ol.FirstName))
-        .ForMember(dto => dto.LastName, conf => conf.MapFrom(ol => ol.LastName)));
-      Mapper.Configuration.AssertConfigurationIsValid();
+        private readonly IUserRepository _userRepository;
+
+        public static void Initialize()
+        {
+            Mapper.Initialize(cfg => cfg.CreateMap<UserEntity, UserReport>()
+              .ForMember(dto => dto.FirstName, conf => conf.MapFrom(ol => ol.FirstName))
+              .ForMember(dto => dto.LastName, conf => conf.MapFrom(ol => ol.LastName)));
+            Mapper.Configuration.AssertConfigurationIsValid();
+        }
+
+        public MyService(IUserRepository userRepository)
+        {
+            _userRepository = userRepository;
+        }
+
+        public async Task CreateUserIfNotExist(string firstName, string lastName, DateTime dateOfBirth)
+        {
+            var query = _userRepository.GetQueryable();
+
+            if (await query.AnyAsync(x => x.LastName == lastName && x.DateOfBirth == dateOfBirth))
+            {
+                throw new ApplicationException("User already exist");
+            }
+
+            var existUser = await query.FirstOrDefaultAsync(x => x.FirstName == firstName);
+            if (existUser != null)
+            {
+                throw new ApplicationException("User with FirstName already exist");
+            }
+
+            if (await query.CountAsync(x => x.DateOfBirth == dateOfBirth.Date) > 3)
+            {
+                throw new ApplicationException("Users with DateOfBirth more than limit");
+            }
+
+            await _userRepository.CreateUser(new UserEntity
+            {
+                FirstName = firstName,
+                LastName = lastName,
+                DateOfBirth = dateOfBirth.Date,
+            });
+
+        }
+
+        public async Task<List<UserReport>> GetUserReports(DateTime dateFrom, DateTime dateTo)
+        {
+            var query = _userRepository.GetQueryable();
+
+            query = query.Where(x => x.DateOfBirth >= dateFrom.Date);
+            query = query.Where(x => x.DateOfBirth <= dateTo.Date);
+
+            return await query.Select(x => new UserReport
+            {
+                FirstName = x.FirstName,
+                LastName = x.LastName,
+            }).ToListAsync();
+        }
+
+
+        public async Task<List<UserReport>> GetUserReportsAutoMap(DateTime dateFrom, DateTime dateTo)
+        {
+            var query = _userRepository.GetQueryable();
+
+            query = query.Where(x => x.DateOfBirth >= dateFrom.Date);
+            query = query.Where(x => x.DateOfBirth <= dateTo.Date);
+
+            return await query.ProjectTo<UserReport>().ToListAsync();
+        }
     }
 
-    public MyService(IUserRepository userRepository)
+    public interface IUserRepository
     {
-      _userRepository = userRepository;
+        IQueryable<UserEntity> GetQueryable();
+
+        Task CreateUser(UserEntity user);
+
+        Task<List<UserEntity>> GetAll();
+
+        IAsyncEnumerable<UserEntity> GetAllAsync();
+
+        Task<int> DeleteUserAsync(Guid id);
+
+        Task<int> UpdateFirstNameByIdAsync(Guid id, string firstName);
     }
 
-    public async Task CreateUserIfNotExist(string firstName, string lastName, DateTime dateOfBirth)
+    public class UserReport
     {
-      var query = _userRepository.GetQueryable();
-
-      if (await query.AnyAsync(x => x.LastName == lastName && x.DateOfBirth == dateOfBirth))
-      {
-        throw new ApplicationException("User already exist");
-      }
-
-      var existUser = await query.FirstOrDefaultAsync(x => x.FirstName == firstName);
-      if (existUser != null)
-      {
-        throw new ApplicationException("User with FirstName already exist");
-      }
-
-      if (await query.CountAsync(x => x.DateOfBirth == dateOfBirth.Date) > 3)
-      {
-        throw new ApplicationException("Users with DateOfBirth more than limit");
-      }
-
-      await _userRepository.CreateUser(new UserEntity
-      {
-        FirstName = firstName,
-        LastName = lastName,
-        DateOfBirth = dateOfBirth.Date,
-      });
-
+        public string FirstName { get; set; }
+        public string LastName { get; set; }
     }
 
-    public async Task<List<UserReport>> GetUserReports(DateTime dateFrom, DateTime dateTo)
+    public class UserEntity
     {
-      var query = _userRepository.GetQueryable();
-
-      query = query.Where(x => x.DateOfBirth >= dateFrom.Date);
-      query = query.Where(x => x.DateOfBirth <= dateTo.Date);
-
-      return await query.Select(x => new UserReport
-      {
-        FirstName = x.FirstName,
-        LastName = x.LastName,
-      }).ToListAsync();
+        public Guid Id { get; set; }
+        public string FirstName { get; set; }
+        public string LastName { get; set; }
+        public DateTime DateOfBirth { get; set; }
     }
-
-
-    public async Task<List<UserReport>> GetUserReportsAutoMap(DateTime dateFrom, DateTime dateTo)
-    {
-      var query = _userRepository.GetQueryable();
-
-      query = query.Where(x => x.DateOfBirth >= dateFrom.Date);
-      query = query.Where(x => x.DateOfBirth <= dateTo.Date);
-
-      return await query.ProjectTo<UserReport>().ToListAsync();
-    }
-  }
-
-  public interface IUserRepository
-  {
-    IQueryable<UserEntity> GetQueryable();
-
-    Task CreateUser(UserEntity user);
-
-    Task<List<UserEntity>> GetAll();
-
-    IAsyncEnumerable<UserEntity> GetAllAsync();
-  }
-
-
-  public class UserReport
-  {
-    public string FirstName { get; set; }
-    public string LastName { get; set; }
-  }
-
-  public class UserEntity
-  {
-    public Guid Id { get; set; }
-    public string FirstName { get; set; }
-    public string LastName { get; set; }
-    public DateTime DateOfBirth { get; set; }
-  }
 }

--- a/src/MockQueryable/MockQueryable.Sample/MyServiceMoqTests.cs
+++ b/src/MockQueryable/MockQueryable.Sample/MyServiceMoqTests.cs
@@ -1,30 +1,30 @@
-﻿using System;
+﻿using Microsoft.EntityFrameworkCore;
+using MockQueryable.Moq;
+using Moq;
+using NUnit.Framework;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.EntityFrameworkCore;
-using MockQueryable.Moq;
-using Moq;
-using NUnit.Framework;
 
 namespace MockQueryable.Sample
 {
     [TestFixture]
-  public class MyServiceMoqTests
-  {
-    private static readonly CultureInfo UsCultureInfo = new CultureInfo("en-US");
-
-    [TestCase("AnyFirstName", "AnyExistLastName", "01/20/2012", "Users with DateOfBirth more than limit")]
-    [TestCase("ExistFirstName", "AnyExistLastName", "02/20/2012", "User with FirstName already exist")]
-    [TestCase("AnyFirstName", "ExistLastName", "01/20/2012", "User already exist")]
-    public void CreateUserIfNotExist(string firstName, string lastName, DateTime dateOfBirth, string expectedError)
+    public class MyServiceMoqTests
     {
-      //arrange
-      var userRepository = new Mock<IUserRepository>();
-      var service = new MyService(userRepository.Object);
-      var users = new List<UserEntity>
+        private static readonly CultureInfo UsCultureInfo = new CultureInfo("en-US");
+
+        [TestCase("AnyFirstName", "AnyExistLastName", "01/20/2012", "Users with DateOfBirth more than limit")]
+        [TestCase("ExistFirstName", "AnyExistLastName", "02/20/2012", "User with FirstName already exist")]
+        [TestCase("AnyFirstName", "ExistLastName", "01/20/2012", "User already exist")]
+        public void CreateUserIfNotExist(string firstName, string lastName, DateTime dateOfBirth, string expectedError)
+        {
+            //arrange
+            var userRepository = new Mock<IUserRepository>();
+            var service = new MyService(userRepository.Object);
+            var users = new List<UserEntity>
       {
         new UserEntity {LastName = "ExistLastName", DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat)},
         new UserEntity {FirstName = "ExistFirstName"},
@@ -32,64 +32,64 @@ namespace MockQueryable.Sample
         new UserEntity {DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat)},
         new UserEntity {DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat)}
       };
-      //expect
-      var mock = users.BuildMock();
-      userRepository.Setup(x => x.GetQueryable()).Returns(mock);
-      //act
-      var ex = Assert.ThrowsAsync<ApplicationException>(() =>
-        service.CreateUserIfNotExist(firstName, lastName, dateOfBirth));
-      //assert
-      Assert.AreEqual(expectedError, ex.Message);
-    }
+            //expect
+            var mock = users.BuildMock();
+            userRepository.Setup(x => x.GetQueryable()).Returns(mock);
+            //act
+            var ex = Assert.ThrowsAsync<ApplicationException>(() =>
+              service.CreateUserIfNotExist(firstName, lastName, dateOfBirth));
+            //assert
+            Assert.AreEqual(expectedError, ex.Message);
+        }
 
-    [TestCase("01/20/2012", "06/20/2018", 5)]
-    [TestCase("01/20/2012", "06/20/2012", 4)]
-    [TestCase("01/20/2012", "02/20/2012", 3)]
-    [TestCase("01/20/2010", "02/20/2011", 0)]
-    public async Task GetUserReports(DateTime from, DateTime to, int expectedCount)
-    {
-      //arrange
-      var userRepository = new Mock<IUserRepository>();
-      var service = new MyService(userRepository.Object);
-      var users = CreateUserList();
-      //expect
-      var mock = users.BuildMock();
-      userRepository.Setup(x => x.GetQueryable()).Returns(mock);
-      //act
-      var result = await service.GetUserReports(from, to);
-      //assert
-      Assert.AreEqual(expectedCount, result.Count);
-    }
-
-
-
-    [TestCase("01/20/2012", "06/20/2018", 5)]
-    [TestCase("01/20/2012", "06/20/2012", 4)]
-    [TestCase("01/20/2012", "02/20/2012", 3)]
-    [TestCase("01/20/2010", "02/20/2011", 0)]
-    public async Task GetUserReports_AutoMap(DateTime from, DateTime to, int expectedCount)
-    {
-      //arrange
-      var userRepository = new Mock<IUserRepository>();
-      var service = new MyService(userRepository.Object);
-      var users = CreateUserList();
-      //expect
-      var mock = users.BuildMock();
-      userRepository.Setup(x => x.GetQueryable()).Returns(mock);
-      //act
-      var result = await service.GetUserReportsAutoMap(from, to);
-      //assert
-      Assert.AreEqual(expectedCount, result.Count);
-    }
+        [TestCase("01/20/2012", "06/20/2018", 5)]
+        [TestCase("01/20/2012", "06/20/2012", 4)]
+        [TestCase("01/20/2012", "02/20/2012", 3)]
+        [TestCase("01/20/2010", "02/20/2011", 0)]
+        public async Task GetUserReports(DateTime from, DateTime to, int expectedCount)
+        {
+            //arrange
+            var userRepository = new Mock<IUserRepository>();
+            var service = new MyService(userRepository.Object);
+            var users = CreateUserList();
+            //expect
+            var mock = users.BuildMock();
+            userRepository.Setup(x => x.GetQueryable()).Returns(mock);
+            //act
+            var result = await service.GetUserReports(from, to);
+            //assert
+            Assert.AreEqual(expectedCount, result.Count);
+        }
 
 
-    [TestCase("AnyFirstName", "AnyExistLastName", "01/20/2012", "Users with DateOfBirth more than limit")]
-    [TestCase("ExistFirstName", "AnyExistLastName", "02/20/2012", "User with FirstName already exist")]
-    [TestCase("AnyFirstName", "ExistLastName", "01/20/2012", "User already exist")]
-    public void DbSetCreateUserIfNotExist(string firstName, string lastName, DateTime dateOfBirth, string expectedError)
-    {
-      //arrange
-      var users = new List<UserEntity>
+
+        [TestCase("01/20/2012", "06/20/2018", 5)]
+        [TestCase("01/20/2012", "06/20/2012", 4)]
+        [TestCase("01/20/2012", "02/20/2012", 3)]
+        [TestCase("01/20/2010", "02/20/2011", 0)]
+        public async Task GetUserReports_AutoMap(DateTime from, DateTime to, int expectedCount)
+        {
+            //arrange
+            var userRepository = new Mock<IUserRepository>();
+            var service = new MyService(userRepository.Object);
+            var users = CreateUserList();
+            //expect
+            var mock = users.BuildMock();
+            userRepository.Setup(x => x.GetQueryable()).Returns(mock);
+            //act
+            var result = await service.GetUserReportsAutoMap(from, to);
+            //assert
+            Assert.AreEqual(expectedCount, result.Count);
+        }
+
+
+        [TestCase("AnyFirstName", "AnyExistLastName", "01/20/2012", "Users with DateOfBirth more than limit")]
+        [TestCase("ExistFirstName", "AnyExistLastName", "02/20/2012", "User with FirstName already exist")]
+        [TestCase("AnyFirstName", "ExistLastName", "01/20/2012", "User already exist")]
+        public void DbSetCreateUserIfNotExist(string firstName, string lastName, DateTime dateOfBirth, string expectedError)
+        {
+            //arrange
+            var users = new List<UserEntity>
       {
         new UserEntity {LastName = "ExistLastName", DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat)},
         new UserEntity {FirstName = "ExistFirstName"},
@@ -97,23 +97,23 @@ namespace MockQueryable.Sample
         new UserEntity {DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat)},
         new UserEntity {DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat)}
       };
-      var mock = users.AsQueryable().BuildMockDbSet();
-      var userRepository = new TestDbSetRepository(mock.Object);
-      var service = new MyService(userRepository);
-      //act
-      var ex = Assert.ThrowsAsync<ApplicationException>(() =>
-        service.CreateUserIfNotExist(firstName, lastName, dateOfBirth));
-      //assert
-      Assert.AreEqual(expectedError, ex.Message);
-    }
+            var mock = users.AsQueryable().BuildMockDbSet();
+            var userRepository = new TestDbSetRepository(mock.Object);
+            var service = new MyService(userRepository);
+            //act
+            var ex = Assert.ThrowsAsync<ApplicationException>(() =>
+              service.CreateUserIfNotExist(firstName, lastName, dateOfBirth));
+            //assert
+            Assert.AreEqual(expectedError, ex.Message);
+        }
 
-    [TestCase("AnyFirstName", "AnyExistLastName", "01/20/2012", "Users with DateOfBirth more than limit")]
-    [TestCase("ExistFirstName", "AnyExistLastName", "02/20/2012", "User with FirstName already exist")]
-    [TestCase("AnyFirstName", "ExistLastName", "01/20/2012", "User already exist")]
-    public void DbSetCreatedFromCollectionCreateUserIfNotExist(string firstName, string lastName, DateTime dateOfBirth, string expectedError)
-    {
-        //arrange
-        var users = new List<UserEntity>
+        [TestCase("AnyFirstName", "AnyExistLastName", "01/20/2012", "Users with DateOfBirth more than limit")]
+        [TestCase("ExistFirstName", "AnyExistLastName", "02/20/2012", "User with FirstName already exist")]
+        [TestCase("AnyFirstName", "ExistLastName", "01/20/2012", "User already exist")]
+        public void DbSetCreatedFromCollectionCreateUserIfNotExist(string firstName, string lastName, DateTime dateOfBirth, string expectedError)
+        {
+            //arrange
+            var users = new List<UserEntity>
         {
             new UserEntity {LastName = "ExistLastName", DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat)},
             new UserEntity {FirstName = "ExistFirstName"},
@@ -121,122 +121,122 @@ namespace MockQueryable.Sample
             new UserEntity {DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat)},
             new UserEntity {DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat)}
         };
-        var mock = users.BuildMockDbSet();
-        var userRepository = new TestDbSetRepository(mock.Object);
-        var service = new MyService(userRepository);
-        //act
-        var ex = Assert.ThrowsAsync<ApplicationException>(() =>
-                                                              service.CreateUserIfNotExist(firstName, lastName, dateOfBirth));
-        //assert
-        Assert.AreEqual(expectedError, ex.Message);
-    }
+            var mock = users.BuildMockDbSet();
+            var userRepository = new TestDbSetRepository(mock.Object);
+            var service = new MyService(userRepository);
+            //act
+            var ex = Assert.ThrowsAsync<ApplicationException>(() =>
+                                                                  service.CreateUserIfNotExist(firstName, lastName, dateOfBirth));
+            //assert
+            Assert.AreEqual(expectedError, ex.Message);
+        }
 
         [TestCase("AnyFirstName", "ExistLastName", "01/20/2012")]
-    public async Task DbSetCreateUser(string firstName, string lastName, DateTime dateOfBirth)
-    {
-      //arrange
-      var userEntities = new List<UserEntity>();
-      var mock = userEntities.AsQueryable().BuildMockDbSet();
+        public async Task DbSetCreateUser(string firstName, string lastName, DateTime dateOfBirth)
+        {
+            //arrange
+            var userEntities = new List<UserEntity>();
+            var mock = userEntities.AsQueryable().BuildMockDbSet();
 
-      mock.Setup(set => set.AddAsync(It.IsAny<UserEntity>(), It.IsAny<CancellationToken>()))
-          .Callback((UserEntity entity, CancellationToken _) => userEntities.Add(entity));
+            mock.Setup(set => set.AddAsync(It.IsAny<UserEntity>(), It.IsAny<CancellationToken>()))
+                .Callback((UserEntity entity, CancellationToken _) => userEntities.Add(entity));
             var userRepository = new TestDbSetRepository(mock.Object);
-      var service = new MyService(userRepository);
-      //act
-      await service.CreateUserIfNotExist(firstName, lastName, dateOfBirth);
-      // assert
-      var entity = mock.Object.Single();
-      Assert.AreEqual(firstName, entity.FirstName);
-      Assert.AreEqual(lastName, entity.LastName);
-      Assert.AreEqual(dateOfBirth, entity.DateOfBirth);
-    }
+            var service = new MyService(userRepository);
+            //act
+            await service.CreateUserIfNotExist(firstName, lastName, dateOfBirth);
+            // assert
+            var entity = mock.Object.Single();
+            Assert.AreEqual(firstName, entity.FirstName);
+            Assert.AreEqual(lastName, entity.LastName);
+            Assert.AreEqual(dateOfBirth, entity.DateOfBirth);
+        }
 
-    [TestCase("AnyFirstName", "ExistLastName", "01/20/2012")]
-    public async Task DbSetCreatedFromCollectionCreateUser(string firstName, string lastName, DateTime dateOfBirth)
-    {
-        //arrange
-        var userEntities = new List<UserEntity>();
-        var mock = userEntities.BuildMockDbSet();
+        [TestCase("AnyFirstName", "ExistLastName", "01/20/2012")]
+        public async Task DbSetCreatedFromCollectionCreateUser(string firstName, string lastName, DateTime dateOfBirth)
+        {
+            //arrange
+            var userEntities = new List<UserEntity>();
+            var mock = userEntities.BuildMockDbSet();
 
-        mock.Setup(set => set.AddAsync(It.IsAny<UserEntity>(), It.IsAny<CancellationToken>()))
-            .Callback((UserEntity entity, CancellationToken _) => userEntities.Add(entity));
-        var userRepository = new TestDbSetRepository(mock.Object);
-        var service = new MyService(userRepository);
-        //act
-        await service.CreateUserIfNotExist(firstName, lastName, dateOfBirth);
-        // assert
-        var entity = mock.Object.Single();
-        Assert.AreEqual(firstName, entity.FirstName);
-        Assert.AreEqual(lastName, entity.LastName);
-        Assert.AreEqual(dateOfBirth, entity.DateOfBirth);
-    }
+            mock.Setup(set => set.AddAsync(It.IsAny<UserEntity>(), It.IsAny<CancellationToken>()))
+                .Callback((UserEntity entity, CancellationToken _) => userEntities.Add(entity));
+            var userRepository = new TestDbSetRepository(mock.Object);
+            var service = new MyService(userRepository);
+            //act
+            await service.CreateUserIfNotExist(firstName, lastName, dateOfBirth);
+            // assert
+            var entity = mock.Object.Single();
+            Assert.AreEqual(firstName, entity.FirstName);
+            Assert.AreEqual(lastName, entity.LastName);
+            Assert.AreEqual(dateOfBirth, entity.DateOfBirth);
+        }
 
         [TestCase("01/20/2012", "06/20/2018", 5)]
-    [TestCase("01/20/2012", "06/20/2012", 4)]
-    [TestCase("01/20/2012", "02/20/2012", 3)]
-    [TestCase("01/20/2010", "02/20/2011", 0)]
-    public async Task DbSetGetUserReports(DateTime from, DateTime to, int expectedCount)
-    {
-      //arrange
-      var users = CreateUserList();
-      var mock = users.AsQueryable().BuildMockDbSet();
-      var userRepository = new TestDbSetRepository(mock.Object);
-      var service = new MyService(userRepository);
-      //act
-      var result = await service.GetUserReports(from, to);
-      //assert
-      Assert.AreEqual(expectedCount, result.Count);
-    }
+        [TestCase("01/20/2012", "06/20/2012", 4)]
+        [TestCase("01/20/2012", "02/20/2012", 3)]
+        [TestCase("01/20/2010", "02/20/2011", 0)]
+        public async Task DbSetGetUserReports(DateTime from, DateTime to, int expectedCount)
+        {
+            //arrange
+            var users = CreateUserList();
+            var mock = users.AsQueryable().BuildMockDbSet();
+            var userRepository = new TestDbSetRepository(mock.Object);
+            var service = new MyService(userRepository);
+            //act
+            var result = await service.GetUserReports(from, to);
+            //assert
+            Assert.AreEqual(expectedCount, result.Count);
+        }
 
-    [TestCase("01/20/2012", "06/20/2018", 5)]
-    [TestCase("01/20/2012", "06/20/2012", 4)]
-    [TestCase("01/20/2012", "02/20/2012", 3)]
-    [TestCase("01/20/2010", "02/20/2011", 0)]
-    public async Task DbSetCreatedFromCollectionGetUserReports(DateTime from, DateTime to, int expectedCount)
-    {
-        //arrange
-        var users = CreateUserList();
-        var mock = users.BuildMockDbSet();
-        var userRepository = new TestDbSetRepository(mock.Object);
-        var service = new MyService(userRepository);
-        //act
-        var result = await service.GetUserReports(from, to);
-        //assert
-        Assert.AreEqual(expectedCount, result.Count);
-    }
-
-        [TestCase]
-    public async Task DbSetGetAllUserEntity()
-    {
-      //arrange
-      var users = CreateUserList();
-      var mock = users.AsQueryable().BuildMockDbSet();
-      var userRepository = new TestDbSetRepository(mock.Object);
-      //act
-      var result = await userRepository.GetAll();
-      //assert
-      Assert.AreEqual(users.Count, result.Count);
-    }
-
-    [TestCase]
-    public async Task DbSetCreatedFromCollectionGetAllUserEntity()
-    {
-        //arrange
-        var users = CreateUserList();
-        var mock = users.BuildMockDbSet();
-        var userRepository = new TestDbSetRepository(mock.Object);
-        //act
-        var result = await userRepository.GetAll();
-        //assert
-        Assert.AreEqual(users.Count, result.Count);
-    }
+        [TestCase("01/20/2012", "06/20/2018", 5)]
+        [TestCase("01/20/2012", "06/20/2012", 4)]
+        [TestCase("01/20/2012", "02/20/2012", 3)]
+        [TestCase("01/20/2010", "02/20/2011", 0)]
+        public async Task DbSetCreatedFromCollectionGetUserReports(DateTime from, DateTime to, int expectedCount)
+        {
+            //arrange
+            var users = CreateUserList();
+            var mock = users.BuildMockDbSet();
+            var userRepository = new TestDbSetRepository(mock.Object);
+            var service = new MyService(userRepository);
+            //act
+            var result = await service.GetUserReports(from, to);
+            //assert
+            Assert.AreEqual(expectedCount, result.Count);
+        }
 
         [TestCase]
-    public async Task DbSetFindAsyncUserEntity()
-    {
-      //arrange
-      var userId = Guid.NewGuid();
-      var users = new List<UserEntity>
+        public async Task DbSetGetAllUserEntity()
+        {
+            //arrange
+            var users = CreateUserList();
+            var mock = users.AsQueryable().BuildMockDbSet();
+            var userRepository = new TestDbSetRepository(mock.Object);
+            //act
+            var result = await userRepository.GetAll();
+            //assert
+            Assert.AreEqual(users.Count, result.Count);
+        }
+
+        [TestCase]
+        public async Task DbSetCreatedFromCollectionGetAllUserEntity()
+        {
+            //arrange
+            var users = CreateUserList();
+            var mock = users.BuildMockDbSet();
+            var userRepository = new TestDbSetRepository(mock.Object);
+            //act
+            var result = await userRepository.GetAll();
+            //assert
+            Assert.AreEqual(users.Count, result.Count);
+        }
+
+        [TestCase]
+        public async Task DbSetFindAsyncUserEntity()
+        {
+            //arrange
+            var userId = Guid.NewGuid();
+            var users = new List<UserEntity>
       {
         new UserEntity
         {
@@ -270,29 +270,29 @@ namespace MockQueryable.Sample
         }
       };
 
-      var mock = users.AsQueryable().BuildMockDbSet();
-      mock.Setup(x => x.FindAsync(It.IsAny<object[]>())).ReturnsAsync((object[] ids) =>
-      {
-        var id = (Guid) ids.First();
-        return users.FirstOrDefault(x => x.Id == id);
-      });
-      var userRepository = new TestDbSetRepository(mock.Object);
+            var mock = users.AsQueryable().BuildMockDbSet();
+            mock.Setup(x => x.FindAsync(It.IsAny<object[]>())).ReturnsAsync((object[] ids) =>
+            {
+                var id = (Guid) ids.First();
+                return users.FirstOrDefault(x => x.Id == id);
+            });
+            var userRepository = new TestDbSetRepository(mock.Object);
 
-      //act
-      var result = await ((DbSet<UserEntity>)userRepository.GetQueryable()).FindAsync(userId);
+            //act
+            var result = await ((DbSet<UserEntity>)userRepository.GetQueryable()).FindAsync(userId);
 
-      //assert
-      Assert.IsNotNull(result);
-      Assert.AreEqual("FirstName3", result.FirstName);
-    }
+            //assert
+            Assert.IsNotNull(result);
+            Assert.AreEqual("FirstName3", result.FirstName);
+        }
 
 
-    [TestCase]
-    public async Task DbSetCreatedFromCollectionFindAsyncUserEntity()
-    {
-        //arrange
-        var userId = Guid.NewGuid();
-        var users = new List<UserEntity>
+        [TestCase]
+        public async Task DbSetCreatedFromCollectionFindAsyncUserEntity()
+        {
+            //arrange
+            var userId = Guid.NewGuid();
+            var users = new List<UserEntity>
         {
             new UserEntity
             {
@@ -326,82 +326,136 @@ namespace MockQueryable.Sample
             }
         };
 
-        var mock = users.BuildMockDbSet();
-        mock.Setup(x => x.FindAsync(It.IsAny<object[]>())).ReturnsAsync((object[] ids) =>
-        {
-            var id = (Guid)ids.First();
-            return users.FirstOrDefault(x => x.Id == id);
-        });
-        var userRepository = new TestDbSetRepository(mock.Object);
+            var mock = users.BuildMockDbSet();
+            mock.Setup(x => x.FindAsync(It.IsAny<object[]>())).ReturnsAsync((object[] ids) =>
+            {
+                var id = (Guid)ids.First();
+                return users.FirstOrDefault(x => x.Id == id);
+            });
+            var userRepository = new TestDbSetRepository(mock.Object);
 
-        //act
-        var result = await ((DbSet<UserEntity>)userRepository.GetQueryable()).FindAsync(userId);
+            //act
+            var result = await ((DbSet<UserEntity>)userRepository.GetQueryable()).FindAsync(userId);
 
-        //assert
-        Assert.IsNotNull(result);
-        Assert.AreEqual("FirstName3", result.FirstName);
-    }
+            //assert
+            Assert.IsNotNull(result);
+            Assert.AreEqual("FirstName3", result.FirstName);
+        }
 
         [TestCase]
-    public async Task DbSetGetAllUserEntitiesAsync()
-    {
-      // arrange
-      var users = CreateUserList();
+        public async Task DbSetGetAllUserEntitiesAsync()
+        {
+            // arrange
+            var users = CreateUserList();
 
-      var mockDbSet = users.AsQueryable().BuildMockDbSet();
-      var userRepository = new TestDbSetRepository(mockDbSet.Object);
+            var mockDbSet = users.AsQueryable().BuildMockDbSet();
+            var userRepository = new TestDbSetRepository(mockDbSet.Object);
 
-      // act
-      var result = await userRepository.GetAllAsync().ToListAsync();
+            // act
+            var result = await userRepository.GetAllAsync().ToListAsync();
 
-      // assert
-      Assert.AreEqual(users.Count, result.Count);
+            // assert
+            Assert.AreEqual(users.Count, result.Count);
+        }
+
+
+        [TestCase]
+        public async Task DbSetToListAsyncAsync_ShouldReturnAllEntities_WhenSourceIsChanged()
+        {
+            // arrange
+            var users = new List<UserEntity>();
+
+            var mockDbSet = users.AsQueryable().BuildMockDbSet();
+
+            // act
+            var result1 = await mockDbSet.Object.ToListAsync();
+            users.AddRange(CreateUserList());
+            var result2 = await mockDbSet.Object.ToListAsync();
+
+            // assert
+            Assert.AreEqual(0, result1.Count);
+            Assert.AreEqual(users.Count, result2.Count);
+        }
+
+        [TestCase]
+        public async Task DbSetCreatedFromCollectionGetAllUserEntitiesAsync()
+        {
+            // arrange
+            var users = CreateUserList();
+
+            var mockDbSet = users.BuildMockDbSet();
+            var userRepository = new TestDbSetRepository(mockDbSet.Object);
+
+            // act
+            var result = await userRepository.GetAllAsync().ToListAsync();
+
+            // assert
+            Assert.AreEqual(users.Count, result.Count);
+        }
+
+        [TestCase]
+        public async Task DbSetCreatedFromCollectionExecuteDeleteAsync()
+        {
+            // arrange
+            var userId = Guid.NewGuid();
+            var users = CreateUserList(userId);
+
+            var mockDbSet = users.BuildMockDbSet();
+            var userRepository = new TestDbSetRepository(mockDbSet.Object);
+
+            var count = await userRepository.DeleteUserAsync(userId);
+            Assert.AreEqual(1, count);
+        }
+
+        [TestCase]
+        public async Task DbSetCreatedFromCollectionExecuteDeleteAsync_ShouldReturnZero()
+        {
+            // arrange
+            var userId = Guid.NewGuid();
+            var users = CreateUserList(userId);
+
+            var mockDbSet = users.BuildMockDbSet();
+            var userRepository = new TestDbSetRepository(mockDbSet.Object);
+
+            var count = await userRepository.DeleteUserAsync(Guid.NewGuid());
+            Assert.AreEqual(0, count);
+        }
+
+        [TestCase]
+        public async Task DbSetCreatedFromCollectionExecuteUpdateAsync()
+        {
+            // arrange
+            var userId = Guid.NewGuid();
+            var users = CreateUserList(userId);
+
+            var mockDbSet = users.BuildMockDbSet();
+            var userRepository = new TestDbSetRepository(mockDbSet.Object);
+
+            var count = await userRepository.UpdateFirstNameByIdAsync(userId, "Unit Test");
+            Assert.AreEqual(1, count);
+        }
+
+        [TestCase]
+        public async Task DbSetCreatedFromCollectionExecuteUpdateAsync_ShouldReturnZero()
+        {
+            // arrange
+            var userId = Guid.NewGuid();
+            var users = CreateUserList(userId);
+
+            var mockDbSet = users.BuildMockDbSet();
+            var userRepository = new TestDbSetRepository(mockDbSet.Object);
+
+            var count = await userRepository.UpdateFirstNameByIdAsync(Guid.NewGuid(), "Unit Test");
+            Assert.AreEqual(0, count);
+        }
+
+        private static List<UserEntity> CreateUserList(Guid? userId = null) => new List<UserEntity>
+        {
+            new UserEntity { Id = userId ?? Guid.NewGuid(), FirstName = "FirstName1", LastName = "LastName", DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat) },
+            new UserEntity { Id = Guid.NewGuid(), FirstName = "FirstName2", LastName = "LastName", DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat) },
+            new UserEntity { Id = Guid.NewGuid(), FirstName = "FirstName3", LastName = "LastName", DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat) },
+            new UserEntity { Id = Guid.NewGuid(), FirstName = "FirstName3", LastName = "LastName", DateOfBirth = DateTime.Parse("03/20/2012", UsCultureInfo.DateTimeFormat) },
+            new UserEntity { Id = Guid.NewGuid(), FirstName = "FirstName5", LastName = "LastName", DateOfBirth = DateTime.Parse("01/20/2018", UsCultureInfo.DateTimeFormat) },
+        };
     }
-    
-    
-    [TestCase]
-    public async Task DbSetToListAsyncAsync_ShouldReturnAllEntities_WhenSourceIsChanged()
-    {
-      // arrange
-      var users = new List<UserEntity>();
-
-      var mockDbSet = users.AsQueryable().BuildMockDbSet();
-
-      // act
-      var result1 = await mockDbSet.Object.ToListAsync();
-      users.AddRange(CreateUserList());
-      var result2 = await mockDbSet.Object.ToListAsync();
-
-      // assert
-      Assert.AreEqual(0, result1.Count);
-      Assert.AreEqual(users.Count, result2.Count);
-    }
-
-
-
-    [TestCase]
-    public async Task DbSetCreatedFromCollectionGetAllUserEntitiesAsync()
-    {
-        // arrange
-        var users = CreateUserList();
-
-        var mockDbSet = users.BuildMockDbSet();
-        var userRepository = new TestDbSetRepository(mockDbSet.Object);
-
-        // act
-        var result = await userRepository.GetAllAsync().ToListAsync();
-
-        // assert
-        Assert.AreEqual(users.Count, result.Count);
-    }
-
-        private static List<UserEntity> CreateUserList() => new List<UserEntity>
-    {
-      new UserEntity { FirstName = "FirstName1", LastName = "LastName", DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat) },
-      new UserEntity { FirstName = "FirstName2", LastName = "LastName", DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat) },
-      new UserEntity { FirstName = "FirstName3", LastName = "LastName", DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat) },
-      new UserEntity { FirstName = "FirstName3", LastName = "LastName", DateOfBirth = DateTime.Parse("03/20/2012", UsCultureInfo.DateTimeFormat) },
-      new UserEntity { FirstName = "FirstName5", LastName = "LastName", DateOfBirth = DateTime.Parse("01/20/2018", UsCultureInfo.DateTimeFormat) },
-    };
-  }
 }

--- a/src/MockQueryable/MockQueryable.Sample/TestDbSetRepository.cs
+++ b/src/MockQueryable/MockQueryable.Sample/TestDbSetRepository.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.EntityFrameworkCore;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -30,6 +31,18 @@ namespace MockQueryable.Sample
         public IAsyncEnumerable<UserEntity> GetAllAsync()
         {
             return _dbSet.AsAsyncEnumerable();
+        }
+
+        public async Task<int> DeleteUserAsync(Guid id)
+        {
+            return await _dbSet.Where(x => x.Id == id)
+                .ExecuteDeleteAsync();
+        }
+
+        public async Task<int> UpdateFirstNameByIdAsync(Guid id, string firstName)
+        {
+            return await _dbSet.Where(x => x.Id == id)
+                .ExecuteUpdateAsync(opt => opt.SetProperty(x => x.FirstName, firstName));
         }
     }
 }


### PR DESCRIPTION
# PR Details
Add Support for ExecuteDelete, ExecuteUpdate, ExecuteDeleteAsync, and ExecuteUpdateAsync in MockQueryable Library

## Description

This PR introduces support for mocking the ExecuteDelete, ExecuteUpdate, ExecuteDeleteAsync, and ExecuteUpdateAsync methods in the MockQueryable library. These methods allow for both synchronous and asynchronous deletion and updating of entities using expressions, now fully integrated into the mocking process for EF Core's IQueryable-based testing.

#### Changes include:

- Adding functionality to mock ExecuteDelete and ExecuteDeleteAsync, returning the number of rows affected based on the provided predicate.
- Adding functionality to mock ExecuteUpdate and ExecuteUpdateAsync, which apply the provided update expression and return the number of rows that would be affected.

## Related Issue

This PR addresses the need to support EF Core 7’s new ExecuteDelete/ExecuteDeleteAsync and ExecuteUpdate/ExecuteUpdateAsync methods in unit tests, enabling developers to simulate bulk delete and update operations without direct access to the database.

Related Issue: #66

## How Has This Been Tested

- Added unit tests covering ExecuteDelete/ExecuteDeleteAsync and ExecuteUpdate/ExecuteUpdateAsync mock scenarios.
- Tested using expressions that target specific rows based on Where filters.
- Verified that both methods (sync and async) correctly return the count of affected rows in different scenarios.
- Ensured all new unit tests passed and that existing tests remained unaffected.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
