### PR TITLE
82 / 73: Update NuGet packages, support for custom ExpressionVisitor

### DIFF
--- a/src/MockQueryable/MockQueryable.EntityFrameworkCore/MockQueryable.EntityFrameworkCore.csproj
+++ b/src/MockQueryable/MockQueryable.EntityFrameworkCore/MockQueryable.EntityFrameworkCore.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net6</TargetFramework>
+		<TargetFramework>net8</TargetFramework>
 		<PackageId>MockQueryable.EntityFrameworkCore</PackageId>
 		<Authors>Roman Titov</Authors>
 		<Description>
@@ -45,7 +45,7 @@
 		</None>
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.0" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.7" />
 	</ItemGroup>
 
   <ItemGroup>

--- a/src/MockQueryable/MockQueryable.EntityFrameworkCore/MockQueryableExtensions.cs
+++ b/src/MockQueryable/MockQueryable.EntityFrameworkCore/MockQueryableExtensions.cs
@@ -1,6 +1,8 @@
-﻿using MockQueryable.EntityFrameworkCore;
+﻿using MockQueryable.Core;
+using MockQueryable.EntityFrameworkCore;
 using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
 
 // Moving MockQueryableExtensions BuildMock into the MockQueryable.EntityFrameworkCore
 // namespace had breaking changes with earlier extensions added to MockQueryable.Moq
@@ -9,11 +11,19 @@ using System.Linq;
 // is dependent on the EF Core AsyncEnumerable.
 namespace MockQueryable
 {
-    public static class MockQueryableExtensions
+  public static class MockQueryableExtensions
+  {
+    public static IQueryable<TEntity> BuildMock<TEntity>(this IEnumerable<TEntity> data)
+     where TEntity : class
     {
-        public static IQueryable<TEntity> BuildMock<TEntity>(this IEnumerable<TEntity> data) where TEntity : class
-        {
-            return new TestAsyncEnumerableEfCore<TEntity>(data);
-        }
+      return new TestAsyncEnumerableEfCore<TEntity, TestExpressionVisitor>(data);
     }
+
+    public static IQueryable<TEntity> BuildMock<TEntity, TExpressionVisitor>(this IEnumerable<TEntity> data)
+      where TEntity : class
+      where TExpressionVisitor : ExpressionVisitor, new()
+    {
+      return new TestAsyncEnumerableEfCore<TEntity, TExpressionVisitor>(data);
+    }
+  }
 }

--- a/src/MockQueryable/MockQueryable.EntityFrameworkCore/TestQueryProviderEfCore.cs
+++ b/src/MockQueryable/MockQueryable.EntityFrameworkCore/TestQueryProviderEfCore.cs
@@ -8,7 +8,8 @@ using MockQueryable.Core;
 
 namespace MockQueryable.EntityFrameworkCore
 {
-  public class TestAsyncEnumerableEfCore<T>: TestQueryProvider<T>, IAsyncEnumerable<T>, IAsyncQueryProvider
+  public class TestAsyncEnumerableEfCore<T, TExpressionVisitor>: TestQueryProvider<T, TExpressionVisitor>, IAsyncEnumerable<T>, IAsyncQueryProvider
+    where TExpressionVisitor : ExpressionVisitor, new()
   {
     public TestAsyncEnumerableEfCore(Expression expression) : base(expression)
     {
@@ -25,11 +26,11 @@ namespace MockQueryable.EntityFrameworkCore
         .GetMethods()
         .First(method => method.Name == nameof(IQueryProvider.Execute) && method.IsGenericMethod)
         .MakeGenericMethod(expectedResultType)
-        .Invoke(this, new object[] { expression });
+        .Invoke(this, [expression]);
 
       return (TResult)typeof(Task).GetMethod(nameof(Task.FromResult))
         .MakeGenericMethod(expectedResultType)
-        .Invoke(null, new[] { executionResult });
+        .Invoke(null, [executionResult]);
     }
 
     public IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default)

--- a/src/MockQueryable/MockQueryable.FakeItEasy/FakeItEasyExtensions.cs
+++ b/src/MockQueryable/MockQueryable.FakeItEasy/FakeItEasyExtensions.cs
@@ -1,68 +1,105 @@
 ﻿using FakeItEasy;
 using Microsoft.EntityFrameworkCore;
+using MockQueryable.Core;
 using MockQueryable.EntityFrameworkCore;
 using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace MockQueryable.FakeItEasy
 {
-    public static class FakeItEasyExtensions
+  public static class FakeItEasyExtensions
+  {
+    public static DbSet<TEntity> BuildMockDbSet<TEntity, TExpressionVisitor>(this IEnumerable<TEntity> data)
+      where TEntity : class
+      where TExpressionVisitor : ExpressionVisitor, new()
+      => data.BuildMock<TEntity, TExpressionVisitor>().BuildMockDbSet();
+
+    public static DbSet<TEntity> BuildMockDbSet<TEntity>(this IEnumerable<TEntity> data)
+      where TEntity : class
+      => data.BuildMock().BuildMockDbSet();
+
+    /// <summary>
+    /// This method allows you to create a mock DbSet for testing purposes.
+    /// It is particularly useful when you want to simulate the behavior of Entity Framework Core's DbSet
+    /// with custom expression handling, such as for testing LINQ queries or database operations.
+    /// The method takes an IQueryable of the entity type and returns a mocked DbSet that implements
+    /// both IAsyncEnumerable and IQueryable interfaces, allowing for asynchronous enumeration
+    /// and LINQ query capabilities.
+    /// </summary>
+    /// <typeparam name="TEntity">
+    /// The type of the entity that the DbSet will represent.
+    /// </typeparam>
+    public static DbSet<TEntity> BuildMockDbSet<TEntity>(this IQueryable<TEntity> data) where TEntity : class
     {
-        public static DbSet<TEntity> BuildMockDbSet<TEntity>(this IEnumerable<TEntity> data) where TEntity : class => data.BuildMock().BuildMockDbSet();
-
-        public static DbSet<TEntity> BuildMockDbSet<TEntity>(this IQueryable<TEntity> data) where TEntity : class
-        {
-            var mock = A.Fake<DbSet<TEntity>>(d => d.Implements<IAsyncEnumerable<TEntity>>().Implements<IQueryable<TEntity>>());
-            var enumerable = new TestAsyncEnumerableEfCore<TEntity>(data);
-            mock.ConfigureQueryableCalls(enumerable, data);
-            mock.ConfigureAsyncEnumerableCalls(enumerable);
-            mock.ConfigureDbSetCalls(data);
-            if (mock is IAsyncEnumerable<TEntity> asyncEnumerable)
-            {
-                A.CallTo(() => asyncEnumerable.GetAsyncEnumerator(A<CancellationToken>.Ignored)).ReturnsLazily(() => enumerable.GetAsyncEnumerator());
-            }
-            return mock;
-        }
-
-
-        private static void ConfigureQueryableCalls<TEntity>(
-            this IQueryable<TEntity> mock,
-            IQueryProvider queryProvider,
-            IQueryable<TEntity> data) where TEntity : class
-        {
-            A.CallTo(() => mock.Provider).Returns(queryProvider);
-            A.CallTo(() => mock.Expression).Returns(data?.Expression);
-            A.CallTo(() => mock.ElementType).Returns(data?.ElementType);
-            A.CallTo(() => mock.GetEnumerator()).ReturnsLazily(() => data?.GetEnumerator());
-        }
-
-        private static void ConfigureAsyncEnumerableCalls<TEntity>(
-            this DbSet<TEntity> mock,
-            IAsyncEnumerable<TEntity> enumerable) where TEntity : class
-        {
-            A.CallTo(() => mock.GetAsyncEnumerator(A<CancellationToken>.Ignored))
-                .Returns(enumerable.GetAsyncEnumerator());
-           
-        }
-
-        private static void ConfigureDbSetCalls<TEntity>(this DbSet<TEntity> mock, IQueryable<TEntity> data)
-          where TEntity : class
-        {
-            A.CallTo(() => mock.AsQueryable()).Returns(data);
-            A.CallTo(() => mock.AsAsyncEnumerable()).ReturnsLazily(args => CreateAsyncMock(data));
-        }
-
-        private static async IAsyncEnumerable<TEntity> CreateAsyncMock<TEntity>(IEnumerable<TEntity> data)
-          where TEntity : class
-        {
-            foreach (var entity in data)
-            {
-                yield return entity;
-            }
-
-            await Task.CompletedTask;
-        }
+      return BuildMockDbSet<TEntity, TestExpressionVisitor>(data);
     }
+
+    /// <summary>
+    /// See <see cref="BuildMockDbSet{TEntity}"/>.
+    /// </summary>
+    /// <typeparam name="TEntity">
+    /// The type of the entity that the DbSet will represent.
+    /// </typeparam>
+    /// <typeparam name="TExpressionVisitor">
+    /// The type of the expression visitor that will be used to process LINQ expressions.
+    /// Can be used to mock EF Core specific expression handling, such as for ILike expressions.
+    /// </typeparam>
+    public static DbSet<TEntity> BuildMockDbSet<TEntity, TExpressionVisitor>(this IQueryable<TEntity> data)
+      where TEntity : class
+      where TExpressionVisitor : ExpressionVisitor, new()
+    {
+      var mock = A.Fake<DbSet<TEntity>>(d => d.Implements<IAsyncEnumerable<TEntity>>().Implements<IQueryable<TEntity>>());
+      var enumerable = new TestAsyncEnumerableEfCore<TEntity, TExpressionVisitor>(data);
+      mock.ConfigureQueryableCalls(enumerable, data);
+      mock.ConfigureAsyncEnumerableCalls(enumerable);
+      mock.ConfigureDbSetCalls(data);
+
+      if (mock is IAsyncEnumerable<TEntity> asyncEnumerable)
+      {
+        A.CallTo(() => asyncEnumerable.GetAsyncEnumerator(A<CancellationToken>.Ignored)).ReturnsLazily(() => enumerable.GetAsyncEnumerator());
+      }
+
+      return mock;
+    }
+
+    private static void ConfigureQueryableCalls<TEntity>(
+        this IQueryable<TEntity> mock,
+        IQueryProvider queryProvider,
+        IQueryable<TEntity> data) where TEntity : class
+    {
+      A.CallTo(() => mock.Provider).Returns(queryProvider);
+      A.CallTo(() => mock.Expression).Returns(data?.Expression);
+      A.CallTo(() => mock.ElementType).Returns(data?.ElementType);
+      A.CallTo(() => mock.GetEnumerator()).ReturnsLazily(() => data?.GetEnumerator());
+    }
+
+    private static void ConfigureAsyncEnumerableCalls<TEntity>(
+        this DbSet<TEntity> mock,
+        IAsyncEnumerable<TEntity> enumerable) where TEntity : class
+    {
+      A.CallTo(() => mock.GetAsyncEnumerator(A<CancellationToken>.Ignored))
+          .Returns(enumerable.GetAsyncEnumerator());
+    }
+
+    private static void ConfigureDbSetCalls<TEntity>(this DbSet<TEntity> mock, IQueryable<TEntity> data)
+      where TEntity : class
+    {
+      A.CallTo(() => mock.AsQueryable()).Returns(data);
+      A.CallTo(() => mock.AsAsyncEnumerable()).ReturnsLazily(args => CreateAsyncMock(data));
+    }
+
+    private static async IAsyncEnumerable<TEntity> CreateAsyncMock<TEntity>(IEnumerable<TEntity> data)
+      where TEntity : class
+    {
+      foreach (var entity in data)
+      {
+        yield return entity;
+      }
+
+      await Task.CompletedTask;
+    }
+  }
 }

--- a/src/MockQueryable/MockQueryable.FakeItEasy/MockQueryable.FakeItEasy.csproj
+++ b/src/MockQueryable/MockQueryable.FakeItEasy/MockQueryable.FakeItEasy.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6</TargetFramework>
+    <TargetFramework>net8</TargetFramework>
     <PackageId>MockQueryable.FakeItEasy</PackageId>
     <Authors>Roman Titov</Authors>
 	  <Description>
@@ -26,7 +26,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FakeItEasy" Version="5.1.1" />
+    <PackageReference Include="FakeItEasy" Version="8.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MockQueryable/MockQueryable.Moq/MockQueryable.Moq.csproj
+++ b/src/MockQueryable/MockQueryable.Moq/MockQueryable.Moq.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6</TargetFramework>
+    <TargetFramework>net8</TargetFramework>
 	  <PackageId>MockQueryable.Moq</PackageId>
     <Authors>Roman Titov</Authors>
 		<Description>
@@ -26,7 +26,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Moq" Version="4.8.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
   </ItemGroup>
 
   

--- a/src/MockQueryable/MockQueryable.Moq/MoqExtensions.cs
+++ b/src/MockQueryable/MockQueryable.Moq/MoqExtensions.cs
@@ -1,32 +1,69 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.EntityFrameworkCore;
+﻿using Microsoft.EntityFrameworkCore;
+using MockQueryable.Core;
 using MockQueryable.EntityFrameworkCore;
 using Moq;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace MockQueryable.Moq
 {
 	public static class MoqExtensions
 	{
         
-		public static Mock<DbSet<TEntity>> BuildMockDbSet<TEntity>(this IEnumerable<TEntity> data) where TEntity : class => data.BuildMock().BuildMockDbSet();
+		public static Mock<DbSet<TEntity>> BuildMockDbSet<TEntity, TExpressionVisitor>(this IEnumerable<TEntity> data)
+			where TEntity : class
+      where TExpressionVisitor : ExpressionVisitor, new()
+      => data.BuildMock<TEntity, TExpressionVisitor>().BuildMockDbSet();
 
-		public static Mock<DbSet<TEntity>> BuildMockDbSet<TEntity>(this IQueryable<TEntity> data) where TEntity : class
+    public static Mock<DbSet<TEntity>> BuildMockDbSet<TEntity>(this IEnumerable<TEntity> data)
+      where TEntity : class
+      => data.BuildMock().BuildMockDbSet();
+
+    /// <summary>
+    /// This method allows you to create a mock DbSet for testing purposes.
+    /// It is particularly useful when you want to simulate the behavior of Entity Framework Core's DbSet
+    /// with custom expression handling, such as for testing LINQ queries or database operations.
+    /// The method takes an IQueryable of the entity type and returns a mocked DbSet that implements
+    /// both IAsyncEnumerable and IQueryable interfaces, allowing for asynchronous enumeration
+    /// and LINQ query capabilities.
+    /// </summary>
+    /// <typeparam name="TEntity">
+    /// The type of the entity that the DbSet will represent.
+    /// </typeparam>
+    public static Mock<DbSet<TEntity>> BuildMockDbSet<TEntity>(this IQueryable<TEntity> data) where TEntity : class
 		{
-			var mock = new Mock<DbSet<TEntity>>();
-			var enumerable = new TestAsyncEnumerableEfCore<TEntity>(data);
-			mock.ConfigureAsyncEnumerableCalls(enumerable);
-			mock.As<IQueryable<TEntity>>().ConfigureQueryableCalls(enumerable, data);
-            mock.As<IAsyncEnumerable<TEntity>>().Setup(x => x.GetAsyncEnumerator(It.IsAny<CancellationToken>())).Returns(() => enumerable.GetAsyncEnumerator());
-			mock.Setup(m => m.AsQueryable()).Returns(enumerable);
+      return BuildMockDbSet<TEntity, TestExpressionVisitor>(data);
+    }
 
-			mock.ConfigureDbSetCalls(data);
-			return mock;
-		}
+    /// <summary>
+    /// See <see cref="BuildMockDbSet{TEntity}"/>.
+    /// </summary>
+    /// <typeparam name="TEntity">
+    /// The type of the entity that the DbSet will represent.
+    /// </typeparam>
+    /// <typeparam name="TExpressionVisitor">
+    /// The type of the expression visitor that will be used to process LINQ expressions.
+    /// Can be used to mock EF Core specific expression handling, such as for ILike expressions.
+    /// </typeparam>
+    public static Mock<DbSet<TEntity>> BuildMockDbSet<TEntity, TExpressionVisitor>(this IQueryable<TEntity> data)
+			where TEntity : class
+      where TExpressionVisitor : ExpressionVisitor, new()
+    {
+      var mock = new Mock<DbSet<TEntity>>();
+      var enumerable = new TestAsyncEnumerableEfCore<TEntity, TExpressionVisitor>(data);
+      mock.ConfigureAsyncEnumerableCalls(enumerable);
+      mock.As<IQueryable<TEntity>>().ConfigureQueryableCalls(enumerable, data);
+      mock.As<IAsyncEnumerable<TEntity>>().Setup(x => x.GetAsyncEnumerator(It.IsAny<CancellationToken>())).Returns(() => enumerable.GetAsyncEnumerator());
+      mock.Setup(m => m.AsQueryable()).Returns(enumerable);
 
-		private static void ConfigureDbSetCalls<TEntity>(this Mock<DbSet<TEntity>> mock, IQueryable<TEntity> data) 
+      mock.ConfigureDbSetCalls(data);
+      return mock;
+    }
+
+    private static void ConfigureDbSetCalls<TEntity>(this Mock<DbSet<TEntity>> mock, IQueryable<TEntity> data) 
 			where TEntity : class
 		{
 			mock.Setup(m => m.AsQueryable()).Returns(mock.Object);

--- a/src/MockQueryable/MockQueryable.NSubstitute/MockQueryable.NSubstitute.csproj
+++ b/src/MockQueryable/MockQueryable.NSubstitute/MockQueryable.NSubstitute.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6</TargetFramework>
+    <TargetFramework>net8</TargetFramework>
 	  <PackageId>MockQueryable.NSubstitute</PackageId>
 		<Authors>Roman Titov</Authors>
 	  <Description>
@@ -26,7 +26,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NSubstitute" Version="4.2.1" />
+    <PackageReference Include="NSubstitute" Version="5.3.0" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Assets\logo.png">

--- a/src/MockQueryable/MockQueryable.NSubstitute/NSubstituteExtensions.cs
+++ b/src/MockQueryable/MockQueryable.NSubstitute/NSubstituteExtensions.cs
@@ -1,8 +1,10 @@
 ﻿using Microsoft.EntityFrameworkCore;
+using MockQueryable.Core;
 using MockQueryable.EntityFrameworkCore;
 using NSubstitute;
 using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -10,12 +12,45 @@ namespace MockQueryable.NSubstitute
 {
   public static class NSubstituteExtensions
   {
+    public static DbSet<TEntity> BuildMockDbSet<TEntity, TExpressionVisitor>(this IEnumerable<TEntity> data)
+      where TEntity : class
+      where TExpressionVisitor : ExpressionVisitor, new()
+      => data.BuildMock<TEntity, TExpressionVisitor>().BuildMockDbSet();
+
     public static DbSet<TEntity> BuildMockDbSet<TEntity>(this IEnumerable<TEntity> data) where TEntity : class => data.BuildMock().BuildMockDbSet();
 
+    /// <summary>
+    /// This method allows you to create a mock DbSet for testing purposes.
+    /// It is particularly useful when you want to simulate the behavior of Entity Framework Core's DbSet
+    /// with custom expression handling, such as for testing LINQ queries or database operations.
+    /// The method takes an IQueryable of the entity type and returns a mocked DbSet that implements
+    /// both IAsyncEnumerable and IQueryable interfaces, allowing for asynchronous enumeration
+    /// and LINQ query capabilities.
+    /// </summary>
+    /// <typeparam name="TEntity">
+    /// The type of the entity that the DbSet will represent.
+    /// </typeparam>
     public static DbSet<TEntity> BuildMockDbSet<TEntity>(this IQueryable<TEntity> data) where TEntity : class
     {
+      return BuildMockDbSet<TEntity, TestExpressionVisitor>(data);
+    }
+
+    /// <summary>
+    /// See <see cref="BuildMockDbSet{TEntity}"/>.
+    /// </summary>
+    /// <typeparam name="TEntity">
+    /// The type of the entity that the DbSet will represent.
+    /// </typeparam>
+    /// <typeparam name="TExpressionVisitor">
+    /// The type of the expression visitor that will be used to process LINQ expressions.
+    /// Can be used to mock EF Core specific expression handling, such as for ILike expressions.
+    /// </typeparam>
+    public static DbSet<TEntity> BuildMockDbSet<TEntity, TExpressionVisitor>(this IQueryable<TEntity> data)
+      where TEntity : class
+      where TExpressionVisitor : ExpressionVisitor, new()
+    {
       var mock = Substitute.For<DbSet<TEntity>, IQueryable<TEntity>, IAsyncEnumerable<TEntity>>();
-      var enumerable = new TestAsyncEnumerableEfCore<TEntity>(data);
+      var enumerable = new TestAsyncEnumerableEfCore<TEntity, TExpressionVisitor>(data);
 
       mock.ConfigureAsyncEnumerableCalls(enumerable);
       mock.ConfigureQueryableCalls(enumerable, data);
@@ -23,12 +58,11 @@ namespace MockQueryable.NSubstitute
 
       if (mock is IAsyncEnumerable<TEntity> asyncEnumerable)
       {
-          asyncEnumerable.GetAsyncEnumerator(Arg.Any<CancellationToken>()).Returns(args => enumerable.GetAsyncEnumerator());
+        asyncEnumerable.GetAsyncEnumerator(Arg.Any<CancellationToken>()).Returns(args => enumerable.GetAsyncEnumerator());
       }
 
       return mock;
     }
-
 
     private static void ConfigureQueryableCalls<TEntity>(
       this IQueryable<TEntity> mock,

--- a/src/MockQueryable/MockQueryable.Sample/MockQueryable.Sample.csproj
+++ b/src/MockQueryable/MockQueryable.Sample/MockQueryable.Sample.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="15.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
     <PackageReference Include="NUnit" Version="4.3.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="5.0.0">
       <PrivateAssets>all</PrivateAssets>

--- a/src/MockQueryable/MockQueryable.Sample/MockQueryable.Sample.csproj
+++ b/src/MockQueryable/MockQueryable.Sample/MockQueryable.Sample.csproj
@@ -1,18 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	  <TargetFramework>net6.0</TargetFramework>
+	  <TargetFramework>net8</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="8.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1">
+    <PackageReference Include="AutoMapper" Version="15.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="NUnit" Version="4.3.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="5.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.Linq.Async" Version="6.0.1" />
+    <PackageReference Include="System.Linq.Async" Version="6.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MockQueryable/MockQueryable.Sample/MyService.cs
+++ b/src/MockQueryable/MockQueryable.Sample/MyService.cs
@@ -12,7 +12,7 @@ namespace MockQueryable.Sample
   public class MyService
   {
     private readonly IUserRepository _userRepository;
-    private static readonly MapperConfiguration _mapperConfiguration = new MapperConfiguration(
+    private static readonly MapperConfiguration _mapperConfiguration = new(
       cfg =>
       {
         cfg.CreateMap<UserEntity, UserReport>()

--- a/src/MockQueryable/MockQueryable.Sample/MyService.cs
+++ b/src/MockQueryable/MockQueryable.Sample/MyService.cs
@@ -5,19 +5,25 @@ using System.Threading.Tasks;
 using AutoMapper;
 using AutoMapper.QueryableExtensions;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 
 namespace MockQueryable.Sample
 {
   public class MyService
   {
     private readonly IUserRepository _userRepository;
+    private static readonly MapperConfiguration _mapperConfiguration = new MapperConfiguration(
+      cfg =>
+      {
+        cfg.CreateMap<UserEntity, UserReport>()
+          .ForMember(dto => dto.FirstName, conf => conf.MapFrom(ol => ol.FirstName))
+          .ForMember(dto => dto.LastName, conf => conf.MapFrom(ol => ol.LastName));
+      },
+      loggerFactory: new LoggerFactory());
 
     public static void Initialize()
     {
-      Mapper.Initialize(cfg => cfg.CreateMap<UserEntity, UserReport>()
-        .ForMember(dto => dto.FirstName, conf => conf.MapFrom(ol => ol.FirstName))
-        .ForMember(dto => dto.LastName, conf => conf.MapFrom(ol => ol.LastName)));
-      Mapper.Configuration.AssertConfigurationIsValid();
+      _mapperConfiguration.AssertConfigurationIsValid();
     }
 
     public MyService(IUserRepository userRepository)
@@ -68,7 +74,6 @@ namespace MockQueryable.Sample
       }).ToListAsync();
     }
 
-
     public async Task<List<UserReport>> GetUserReportsAutoMap(DateTime dateFrom, DateTime dateTo)
     {
       var query = _userRepository.GetQueryable();
@@ -76,7 +81,7 @@ namespace MockQueryable.Sample
       query = query.Where(x => x.DateOfBirth >= dateFrom.Date);
       query = query.Where(x => x.DateOfBirth <= dateTo.Date);
 
-      return await query.ProjectTo<UserReport>().ToListAsync();
+      return await query.ProjectTo<UserReport>(_mapperConfiguration).ToListAsync();
     }
   }
 
@@ -90,7 +95,6 @@ namespace MockQueryable.Sample
 
     IAsyncEnumerable<UserEntity> GetAllAsync();
   }
-
 
   public class UserReport
   {

--- a/src/MockQueryable/MockQueryable.Sample/MyServiceFakeItEasyTests.cs
+++ b/src/MockQueryable/MockQueryable.Sample/MyServiceFakeItEasyTests.cs
@@ -14,34 +14,35 @@ namespace MockQueryable.Sample
   [TestFixture]
   public class MyServiceFakeItEasyTests
   {
-    private static readonly CultureInfo UsCultureInfo = new CultureInfo("en-US");
+    private static readonly CultureInfo UsCultureInfo = new("en-US");
 
     [TestCase("AnyFirstName", "AnyExistLastName", "01/20/2012", "Users with DateOfBirth more than limit")]
     [TestCase("ExistFirstName", "AnyExistLastName", "02/20/2012", "User with FirstName already exist")]
     [TestCase("AnyFirstName", "ExistLastName", "01/20/2012", "User already exist")]
     public void CreateUserIfNotExist(string firstName, string lastName, DateTime dateOfBirth, string expectedError)
     {
-      //arrange
-
+      // arrange
       var userRepository = A.Fake<IUserRepository>();
       var service = new MyService(userRepository);
       var users = new List<UserEntity>
       {
-        new UserEntity {LastName = "ExistLastName", DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat)},
-        new UserEntity {FirstName = "ExistFirstName"},
-        new UserEntity {DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat)},
-        new UserEntity {DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat)},
-        new UserEntity {DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat)},
+        new() {LastName = "ExistLastName", DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat)},
+        new() {FirstName = "ExistFirstName"},
+        new() {DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat)},
+        new() {DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat)},
+        new() {DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat)},
       };
-      //expect
+
+      // expect
       var mock = users.BuildMock();
       A.CallTo(() => userRepository.GetQueryable()).Returns(mock);
-      //act
+
+      // act
       var ex = Assert.ThrowsAsync<ApplicationException>(() =>
         service.CreateUserIfNotExist(firstName, lastName, dateOfBirth));
-      //assert
-      Assert.AreEqual(expectedError, ex.Message);
 
+      // assert
+      Assert.That(expectedError, Is.EqualTo(ex.Message));
     }
 
     [TestCase("01/20/2012", "06/20/2018", 5)]
@@ -60,10 +61,8 @@ namespace MockQueryable.Sample
       //act
       var result = await service.GetUserReports(from, to);
       //assert
-      Assert.AreEqual(expectedCount, result.Count);
-
+      Assert.That(expectedCount, Is.EqualTo(result.Count));
     }
-
 
     [TestCase("01/20/2012", "06/20/2018", 5)]
     [TestCase("01/20/2012", "06/20/2012", 4)]
@@ -71,18 +70,19 @@ namespace MockQueryable.Sample
     [TestCase("01/20/2010", "02/20/2011", 0)]
     public async Task GetUserReports_AutoMap(DateTime from, DateTime to, int expectedCount)
     {
-      //arrange
+      // arrange
       var userRepository = A.Fake<IUserRepository>();
       var service = new MyService(userRepository);
       var users = CreateUserList();
-      //expect
+      // expect
       var mock = users.BuildMock();
       A.CallTo(() => userRepository.GetQueryable()).Returns(mock);
-      //act
-      var result = await service.GetUserReportsAutoMap(from, to);
-      //assert
-      Assert.AreEqual(expectedCount, result.Count);
 
+      // act
+      var result = await service.GetUserReportsAutoMap(from, to);
+
+      // assert
+      Assert.That(expectedCount, Is.EqualTo(result.Count));
     }
 
     [TestCase("AnyFirstName", "AnyExistLastName", "01/20/2012", "Users with DateOfBirth more than limit")]
@@ -90,24 +90,25 @@ namespace MockQueryable.Sample
     [TestCase("AnyFirstName", "ExistLastName", "01/20/2012", "User already exist")]
     public void DbSetCreateUserIfNotExist(string firstName, string lastName, DateTime dateOfBirth, string expectedError)
     {
-      //arrange
+      // arrange
       var users = new List<UserEntity>
       {
-        new UserEntity {LastName = "ExistLastName", DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat)},
-        new UserEntity {FirstName = "ExistFirstName"},
-        new UserEntity {DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat)},
-        new UserEntity {DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat)},
-        new UserEntity {DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat)},
+        new() {LastName = "ExistLastName", DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat)},
+        new() {FirstName = "ExistFirstName"},
+        new() {DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat)},
+        new() {DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat)},
+        new() {DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat)},
       };
       var mock = users.AsQueryable().BuildMockDbSet();
       var userRepository = new TestDbSetRepository(mock);
       var service = new MyService(userRepository);
-      //act
+
+      // act
       var ex = Assert.ThrowsAsync<ApplicationException>(() =>
         service.CreateUserIfNotExist(firstName, lastName, dateOfBirth));
-      //assert
-      Assert.AreEqual(expectedError, ex.Message);
 
+      // assert
+      Assert.That(expectedError, Is.EqualTo(ex.Message));
     }
 
     [TestCase("AnyFirstName", "AnyExistLastName", "01/20/2012", "Users with DateOfBirth more than limit")]
@@ -115,87 +116,92 @@ namespace MockQueryable.Sample
     [TestCase("AnyFirstName", "ExistLastName", "01/20/2012", "User already exist")]
     public void DbSetCreatedFromCollectionCreateUserIfNotExist(string firstName, string lastName, DateTime dateOfBirth, string expectedError)
     {
-        //arrange
-        var users = new List<UserEntity>
+      // arrange
+      var users = new List<UserEntity>
         {
-            new UserEntity {LastName = "ExistLastName", DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat)},
-            new UserEntity {FirstName = "ExistFirstName"},
-            new UserEntity {DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat)},
-            new UserEntity {DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat)},
-            new UserEntity {DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat)},
+            new() {LastName = "ExistLastName", DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat)},
+            new() {FirstName = "ExistFirstName"},
+            new() {DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat)},
+            new() {DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat)},
+            new() {DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat)},
         };
-        var mock = users.BuildMockDbSet();
-        var userRepository = new TestDbSetRepository(mock);
-        var service = new MyService(userRepository);
-        //act
-        var ex = Assert.ThrowsAsync<ApplicationException>(() =>
-                                                              service.CreateUserIfNotExist(firstName, lastName, dateOfBirth));
-        //assert
-        Assert.AreEqual(expectedError, ex.Message);
-
+      var mock = users.BuildMockDbSet();
+      var userRepository = new TestDbSetRepository(mock);
+      var service = new MyService(userRepository);
+      // act
+      var ex = Assert.ThrowsAsync<ApplicationException>(() =>
+                                                            service.CreateUserIfNotExist(firstName, lastName, dateOfBirth));
+      // assert
+      Assert.That(expectedError, Is.EqualTo(ex.Message));
     }
 
-        [TestCase("AnyFirstName", "ExistLastName", "01/20/2012")]
+    [TestCase("AnyFirstName", "ExistLastName", "01/20/2012")]
     public async Task DbSetCreateUser(string firstName, string lastName, DateTime dateOfBirth)
     {
-      //arrange
+      // arrange
       var userEntities = new List<UserEntity>();
       var mock = userEntities.AsQueryable().BuildMockDbSet();
       A.CallTo(() => mock.AddAsync(A<UserEntity>._, A<CancellationToken>._))
         .ReturnsLazily(call =>
         {
-          userEntities.Add((UserEntity) call.Arguments[0]);
+          userEntities.Add((UserEntity)call.Arguments[0]);
           return default;
         });
       var userRepository = new TestDbSetRepository(mock);
       var service = new MyService(userRepository);
-      //act
+
+      // act
       await service.CreateUserIfNotExist(firstName, lastName, dateOfBirth);
+
       // assert
       var entity = mock.Single();
-      Assert.AreEqual(firstName, entity.FirstName);
-      Assert.AreEqual(lastName, entity.LastName);
-      Assert.AreEqual(dateOfBirth, entity.DateOfBirth);
+      Assert.That(firstName, Is.EqualTo(entity.FirstName));
+      Assert.That(lastName, Is.EqualTo(entity.LastName));
+      Assert.That(dateOfBirth, Is.EqualTo(entity.DateOfBirth));
     }
 
     [TestCase("AnyFirstName", "ExistLastName", "01/20/2012")]
     public async Task DbSetCreatedFromCollectionCreateUser1(string firstName, string lastName, DateTime dateOfBirth)
     {
-        //arrange
-        var userEntities = new List<UserEntity>();
-        var mock = userEntities.BuildMockDbSet();
-        A.CallTo(() => mock.AddAsync(A<UserEntity>._, A<CancellationToken>._))
-         .ReturnsLazily(call =>
-         {
-             userEntities.Add((UserEntity)call.Arguments[0]);
-             return default;
-         });
-        var userRepository = new TestDbSetRepository(mock);
-        var service = new MyService(userRepository);
-        //act
-        await service.CreateUserIfNotExist(firstName, lastName, dateOfBirth);
-        // assert
-        var entity = mock.Single();
-        Assert.AreEqual(firstName, entity.FirstName);
-        Assert.AreEqual(lastName, entity.LastName);
-        Assert.AreEqual(dateOfBirth, entity.DateOfBirth);
+      // arrange
+      var userEntities = new List<UserEntity>();
+      var mock = userEntities.BuildMockDbSet();
+      A.CallTo(() => mock.AddAsync(A<UserEntity>._, A<CancellationToken>._))
+       .ReturnsLazily(call =>
+       {
+         userEntities.Add((UserEntity)call.Arguments[0]);
+         return default;
+       });
+      var userRepository = new TestDbSetRepository(mock);
+      var service = new MyService(userRepository);
+
+      // act
+      await service.CreateUserIfNotExist(firstName, lastName, dateOfBirth);
+
+      // assert
+      var entity = mock.Single();
+      Assert.That(firstName, Is.EqualTo(entity.FirstName));
+      Assert.That(lastName, Is.EqualTo(entity.LastName));
+      Assert.That(dateOfBirth, Is.EqualTo(entity.DateOfBirth));
     }
 
-        [TestCase("01/20/2012", "06/20/2018", 5)]
+    [TestCase("01/20/2012", "06/20/2018", 5)]
     [TestCase("01/20/2012", "06/20/2012", 4)]
     [TestCase("01/20/2012", "02/20/2012", 3)]
     [TestCase("01/20/2010", "02/20/2011", 0)]
     public async Task DbSetGetUserReports(DateTime from, DateTime to, int expectedCount)
     {
-      //arrange
+      // arrange
       var users = CreateUserList();
       var mock = users.AsQueryable().BuildMockDbSet();
       var userRepository = new TestDbSetRepository(mock);
       var service = new MyService(userRepository);
-      //act
+
+      // act
       var result = await service.GetUserReports(from, to);
-      //assert
-      Assert.AreEqual(expectedCount, result.Count);
+
+      // assert
+      Assert.That(expectedCount, Is.EqualTo(result.Count));
     }
 
     [TestCase("01/20/2012", "06/20/2018", 5)]
@@ -204,18 +210,20 @@ namespace MockQueryable.Sample
     [TestCase("01/20/2010", "02/20/2011", 0)]
     public async Task DbSetCreatedFromCollectionGetUserReports(DateTime from, DateTime to, int expectedCount)
     {
-        //arrange
-        var users = CreateUserList();
-        var mock = users.BuildMockDbSet();
-        var userRepository = new TestDbSetRepository(mock);
-        var service = new MyService(userRepository);
-        //act
-        var result = await service.GetUserReports(from, to);
-        //assert
-        Assert.AreEqual(expectedCount, result.Count);
+      // arrange
+      var users = CreateUserList();
+      var mock = users.BuildMockDbSet();
+      var userRepository = new TestDbSetRepository(mock);
+      var service = new MyService(userRepository);
+
+      // act
+      var result = await service.GetUserReports(from, to);
+
+      // assert
+      Assert.That(expectedCount, Is.EqualTo(result.Count));
     }
 
-        [TestCase]
+    [TestCase]
     public async Task DbSetGetAllUserEntitiesAsync()
     {
       // arrange
@@ -228,23 +236,23 @@ namespace MockQueryable.Sample
       var result = await userRepository.GetAllAsync().ToListAsync();
 
       // assert
-      Assert.AreEqual(users.Count, result.Count);
+      Assert.That(users.Count, Is.EqualTo(result.Count));
     }
 
     [TestCase]
     public async Task DbSetCreatedFromCollectionGetAllUserEntitiesAsync()
     {
-        // arrange
-        var users = CreateUserList();
+      // arrange
+      var users = CreateUserList();
 
-        var mockDbSet = users.BuildMockDbSet();
-        var userRepository = new TestDbSetRepository(mockDbSet);
+      var mockDbSet = users.BuildMockDbSet();
+      var userRepository = new TestDbSetRepository(mockDbSet);
 
-        // act
-        var result = await userRepository.GetAllAsync().ToListAsync();
+      // act
+      var result = await userRepository.GetAllAsync().ToListAsync();
 
-        // assert
-        Assert.AreEqual(users.Count, result.Count);
+      // assert
+      Assert.That(users.Count, Is.EqualTo(result.Count));
     }
 
     [TestCase]
@@ -254,44 +262,48 @@ namespace MockQueryable.Sample
       var users = new List<UserEntity>();
 
       var mockDbSet = users.AsQueryable().BuildMockDbSet();
-      
+
       // act
       var result1 = await mockDbSet.ToListAsync();
       users.AddRange(CreateUserList());
       var result2 = await mockDbSet.ToListAsync();
 
       // assert
-      Assert.AreEqual(0, result1.Count);
-      Assert.AreEqual(users.Count, result2.Count);
+      Assert.That(0, Is.EqualTo(result1.Count));
+      Assert.That(users.Count, Is.EqualTo(result2.Count));
     }
 
     [TestCase]
     public async Task DbSetGetAllUserEntity()
     {
-        //arrange
-        var users = CreateUserList();
-        var mock = users.AsQueryable().BuildMockDbSet();
-        var userRepository = new TestDbSetRepository(mock);
-        //act
-        var result = await userRepository.GetAll();
-        //assert
-        Assert.AreEqual(users.Count, result.Count);
+      //arrange
+      var users = CreateUserList();
+      var mock = users.AsQueryable().BuildMockDbSet();
+      var userRepository = new TestDbSetRepository(mock);
+
+      //act
+      var result = await userRepository.GetAll();
+
+      //assert
+      Assert.That(users.Count, Is.EqualTo(result.Count));
     }
 
     [TestCase]
     public async Task DbSetCreatedFromCollectionGetAllUserEntity()
     {
-        //arrange
-        var users = CreateUserList();
-        var mock = users.BuildMockDbSet();
-        var userRepository = new TestDbSetRepository(mock);
-        //act
-        var result = await userRepository.GetAll();
-        //assert
-        Assert.AreEqual(users.Count, result.Count);
+      // arrange
+      var users = CreateUserList();
+      var mock = users.BuildMockDbSet();
+      var userRepository = new TestDbSetRepository(mock);
+
+      // act
+      var result = await userRepository.GetAll();
+
+      // assert
+      Assert.That(users.Count, Is.EqualTo(result.Count));
     }
 
-        private static List<UserEntity> CreateUserList() => new List<UserEntity>
+    private static List<UserEntity> CreateUserList() => new()
     {
       new UserEntity
       {
@@ -319,7 +331,5 @@ namespace MockQueryable.Sample
         DateOfBirth = DateTime.Parse("01/20/2018", UsCultureInfo.DateTimeFormat)
       },
     };
-
-
   }
 }

--- a/src/MockQueryable/MockQueryable.Sample/MyServiceMoqTests.cs
+++ b/src/MockQueryable/MockQueryable.Sample/MyServiceMoqTests.cs
@@ -11,10 +11,10 @@ using NUnit.Framework;
 
 namespace MockQueryable.Sample
 {
-    [TestFixture]
+  [TestFixture]
   public class MyServiceMoqTests
   {
-    private static readonly CultureInfo UsCultureInfo = new CultureInfo("en-US");
+    private static readonly CultureInfo UsCultureInfo = new("en-US");
 
     [TestCase("AnyFirstName", "AnyExistLastName", "01/20/2012", "Users with DateOfBirth more than limit")]
     [TestCase("ExistFirstName", "AnyExistLastName", "02/20/2012", "User with FirstName already exist")]
@@ -26,11 +26,11 @@ namespace MockQueryable.Sample
       var service = new MyService(userRepository.Object);
       var users = new List<UserEntity>
       {
-        new UserEntity {LastName = "ExistLastName", DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat)},
-        new UserEntity {FirstName = "ExistFirstName"},
-        new UserEntity {DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat)},
-        new UserEntity {DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat)},
-        new UserEntity {DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat)}
+        new() {LastName = "ExistLastName", DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat)},
+        new() {FirstName = "ExistFirstName"},
+        new() {DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat)},
+        new() {DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat)},
+        new() {DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat)}
       };
       //expect
       var mock = users.BuildMock();
@@ -39,7 +39,7 @@ namespace MockQueryable.Sample
       var ex = Assert.ThrowsAsync<ApplicationException>(() =>
         service.CreateUserIfNotExist(firstName, lastName, dateOfBirth));
       //assert
-      Assert.AreEqual(expectedError, ex.Message);
+      Assert.That(expectedError, Is.EqualTo(ex.Message));
     }
 
     [TestCase("01/20/2012", "06/20/2018", 5)]
@@ -58,7 +58,7 @@ namespace MockQueryable.Sample
       //act
       var result = await service.GetUserReports(from, to);
       //assert
-      Assert.AreEqual(expectedCount, result.Count);
+      Assert.That(expectedCount, Is.EqualTo(result.Count));
     }
 
 
@@ -79,7 +79,7 @@ namespace MockQueryable.Sample
       //act
       var result = await service.GetUserReportsAutoMap(from, to);
       //assert
-      Assert.AreEqual(expectedCount, result.Count);
+      Assert.That(expectedCount, Is.EqualTo(result.Count));
     }
 
 
@@ -91,11 +91,11 @@ namespace MockQueryable.Sample
       //arrange
       var users = new List<UserEntity>
       {
-        new UserEntity {LastName = "ExistLastName", DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat)},
-        new UserEntity {FirstName = "ExistFirstName"},
-        new UserEntity {DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat)},
-        new UserEntity {DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat)},
-        new UserEntity {DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat)}
+        new() {LastName = "ExistLastName", DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat)},
+        new() {FirstName = "ExistFirstName"},
+        new() {DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat)},
+        new() {DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat)},
+        new() {DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat)}
       };
       var mock = users.AsQueryable().BuildMockDbSet();
       var userRepository = new TestDbSetRepository(mock.Object);
@@ -104,7 +104,7 @@ namespace MockQueryable.Sample
       var ex = Assert.ThrowsAsync<ApplicationException>(() =>
         service.CreateUserIfNotExist(firstName, lastName, dateOfBirth));
       //assert
-      Assert.AreEqual(expectedError, ex.Message);
+      Assert.That(expectedError, Is.EqualTo(ex.Message));
     }
 
     [TestCase("AnyFirstName", "AnyExistLastName", "01/20/2012", "Users with DateOfBirth more than limit")]
@@ -112,26 +112,26 @@ namespace MockQueryable.Sample
     [TestCase("AnyFirstName", "ExistLastName", "01/20/2012", "User already exist")]
     public void DbSetCreatedFromCollectionCreateUserIfNotExist(string firstName, string lastName, DateTime dateOfBirth, string expectedError)
     {
-        //arrange
-        var users = new List<UserEntity>
+      //arrange
+      var users = new List<UserEntity>
         {
-            new UserEntity {LastName = "ExistLastName", DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat)},
-            new UserEntity {FirstName = "ExistFirstName"},
-            new UserEntity {DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat)},
-            new UserEntity {DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat)},
-            new UserEntity {DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat)}
+            new() {LastName = "ExistLastName", DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat)},
+            new() {FirstName = "ExistFirstName"},
+            new() {DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat)},
+            new() {DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat)},
+            new() {DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat)}
         };
-        var mock = users.BuildMockDbSet();
-        var userRepository = new TestDbSetRepository(mock.Object);
-        var service = new MyService(userRepository);
-        //act
-        var ex = Assert.ThrowsAsync<ApplicationException>(() =>
-                                                              service.CreateUserIfNotExist(firstName, lastName, dateOfBirth));
-        //assert
-        Assert.AreEqual(expectedError, ex.Message);
+      var mock = users.BuildMockDbSet();
+      var userRepository = new TestDbSetRepository(mock.Object);
+      var service = new MyService(userRepository);
+      //act
+      var ex = Assert.ThrowsAsync<ApplicationException>(() =>
+        service.CreateUserIfNotExist(firstName, lastName, dateOfBirth));
+      //assert
+      Assert.That(expectedError, Is.EqualTo(ex.Message));
     }
 
-        [TestCase("AnyFirstName", "ExistLastName", "01/20/2012")]
+    [TestCase("AnyFirstName", "ExistLastName", "01/20/2012")]
     public async Task DbSetCreateUser(string firstName, string lastName, DateTime dateOfBirth)
     {
       //arrange
@@ -140,38 +140,38 @@ namespace MockQueryable.Sample
 
       mock.Setup(set => set.AddAsync(It.IsAny<UserEntity>(), It.IsAny<CancellationToken>()))
           .Callback((UserEntity entity, CancellationToken _) => userEntities.Add(entity));
-            var userRepository = new TestDbSetRepository(mock.Object);
+      var userRepository = new TestDbSetRepository(mock.Object);
       var service = new MyService(userRepository);
       //act
       await service.CreateUserIfNotExist(firstName, lastName, dateOfBirth);
       // assert
       var entity = mock.Object.Single();
-      Assert.AreEqual(firstName, entity.FirstName);
-      Assert.AreEqual(lastName, entity.LastName);
-      Assert.AreEqual(dateOfBirth, entity.DateOfBirth);
+      Assert.That(firstName, Is.EqualTo(entity.FirstName));
+      Assert.That(lastName, Is.EqualTo(entity.LastName));
+      Assert.That(dateOfBirth, Is.EqualTo(entity.DateOfBirth));
     }
 
     [TestCase("AnyFirstName", "ExistLastName", "01/20/2012")]
     public async Task DbSetCreatedFromCollectionCreateUser(string firstName, string lastName, DateTime dateOfBirth)
     {
-        //arrange
-        var userEntities = new List<UserEntity>();
-        var mock = userEntities.BuildMockDbSet();
+      //arrange
+      var userEntities = new List<UserEntity>();
+      var mock = userEntities.BuildMockDbSet();
 
-        mock.Setup(set => set.AddAsync(It.IsAny<UserEntity>(), It.IsAny<CancellationToken>()))
-            .Callback((UserEntity entity, CancellationToken _) => userEntities.Add(entity));
-        var userRepository = new TestDbSetRepository(mock.Object);
-        var service = new MyService(userRepository);
-        //act
-        await service.CreateUserIfNotExist(firstName, lastName, dateOfBirth);
-        // assert
-        var entity = mock.Object.Single();
-        Assert.AreEqual(firstName, entity.FirstName);
-        Assert.AreEqual(lastName, entity.LastName);
-        Assert.AreEqual(dateOfBirth, entity.DateOfBirth);
+      mock.Setup(set => set.AddAsync(It.IsAny<UserEntity>(), It.IsAny<CancellationToken>()))
+          .Callback((UserEntity entity, CancellationToken _) => userEntities.Add(entity));
+      var userRepository = new TestDbSetRepository(mock.Object);
+      var service = new MyService(userRepository);
+      //act
+      await service.CreateUserIfNotExist(firstName, lastName, dateOfBirth);
+      // assert
+      var entity = mock.Object.Single();
+      Assert.That(firstName, Is.EqualTo(entity.FirstName));
+      Assert.That(lastName, Is.EqualTo(entity.LastName));
+      Assert.That(dateOfBirth, Is.EqualTo(entity.DateOfBirth));
     }
 
-        [TestCase("01/20/2012", "06/20/2018", 5)]
+    [TestCase("01/20/2012", "06/20/2018", 5)]
     [TestCase("01/20/2012", "06/20/2012", 4)]
     [TestCase("01/20/2012", "02/20/2012", 3)]
     [TestCase("01/20/2010", "02/20/2011", 0)]
@@ -185,7 +185,7 @@ namespace MockQueryable.Sample
       //act
       var result = await service.GetUserReports(from, to);
       //assert
-      Assert.AreEqual(expectedCount, result.Count);
+      Assert.That(expectedCount, Is.EqualTo(result.Count));
     }
 
     [TestCase("01/20/2012", "06/20/2018", 5)]
@@ -194,18 +194,18 @@ namespace MockQueryable.Sample
     [TestCase("01/20/2010", "02/20/2011", 0)]
     public async Task DbSetCreatedFromCollectionGetUserReports(DateTime from, DateTime to, int expectedCount)
     {
-        //arrange
-        var users = CreateUserList();
-        var mock = users.BuildMockDbSet();
-        var userRepository = new TestDbSetRepository(mock.Object);
-        var service = new MyService(userRepository);
-        //act
-        var result = await service.GetUserReports(from, to);
-        //assert
-        Assert.AreEqual(expectedCount, result.Count);
+      //arrange
+      var users = CreateUserList();
+      var mock = users.BuildMockDbSet();
+      var userRepository = new TestDbSetRepository(mock.Object);
+      var service = new MyService(userRepository);
+      //act
+      var result = await service.GetUserReports(from, to);
+      //assert
+      Assert.That(expectedCount, Is.EqualTo(result.Count));
     }
 
-        [TestCase]
+    [TestCase]
     public async Task DbSetGetAllUserEntity()
     {
       //arrange
@@ -215,55 +215,50 @@ namespace MockQueryable.Sample
       //act
       var result = await userRepository.GetAll();
       //assert
-      Assert.AreEqual(users.Count, result.Count);
+      Assert.That(users.Count, Is.EqualTo(result.Count));
     }
 
     [TestCase]
     public async Task DbSetCreatedFromCollectionGetAllUserEntity()
     {
-        //arrange
-        var users = CreateUserList();
-        var mock = users.BuildMockDbSet();
-        var userRepository = new TestDbSetRepository(mock.Object);
-        //act
-        var result = await userRepository.GetAll();
-        //assert
-        Assert.AreEqual(users.Count, result.Count);
+      //arrange
+      var users = CreateUserList();
+      var mock = users.BuildMockDbSet();
+      var userRepository = new TestDbSetRepository(mock.Object);
+      //act
+      var result = await userRepository.GetAll();
+      //assert
+      Assert.That(users.Count, Is.EqualTo(result.Count));
     }
 
-        [TestCase]
+    [TestCase]
     public async Task DbSetFindAsyncUserEntity()
     {
       //arrange
       var userId = Guid.NewGuid();
       var users = new List<UserEntity>
       {
-        new UserEntity
-        {
+        new() {
           Id = Guid.NewGuid(),
           FirstName = "FirstName1", LastName = "LastName",
           DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat)
         },
-        new UserEntity
-        {
+        new() {
           Id = Guid.NewGuid(),
           FirstName = "FirstName2", LastName = "LastName",
           DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat)
         },
-        new UserEntity
-        {
+        new() {
           Id = userId,
           FirstName = "FirstName3", LastName = "LastName",
           DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat)
         },
-        new UserEntity
-        {
+        new() {
           Id = Guid.NewGuid(),
           FirstName = "FirstName3", LastName = "LastName",
           DateOfBirth = DateTime.Parse("03/20/2012", UsCultureInfo.DateTimeFormat)
         },
-        new UserEntity
-        {
+        new() {
           Id = Guid.NewGuid(),
           FirstName = "FirstName5", LastName = "LastName",
           DateOfBirth = DateTime.Parse("01/20/2018", UsCultureInfo.DateTimeFormat)
@@ -273,7 +268,7 @@ namespace MockQueryable.Sample
       var mock = users.AsQueryable().BuildMockDbSet();
       mock.Setup(x => x.FindAsync(It.IsAny<object[]>())).ReturnsAsync((object[] ids) =>
       {
-        var id = (Guid) ids.First();
+        var id = (Guid)ids.First();
         return users.FirstOrDefault(x => x.Id == id);
       });
       var userRepository = new TestDbSetRepository(mock.Object);
@@ -282,67 +277,62 @@ namespace MockQueryable.Sample
       var result = await ((DbSet<UserEntity>)userRepository.GetQueryable()).FindAsync(userId);
 
       //assert
-      Assert.IsNotNull(result);
-      Assert.AreEqual("FirstName3", result.FirstName);
+      Assert.That(result, Is.Not.Null);
+      Assert.That("FirstName3", Is.EqualTo(result.FirstName));
     }
 
 
     [TestCase]
     public async Task DbSetCreatedFromCollectionFindAsyncUserEntity()
     {
-        //arrange
-        var userId = Guid.NewGuid();
-        var users = new List<UserEntity>
+      //arrange
+      var userId = Guid.NewGuid();
+      var users = new List<UserEntity>
         {
-            new UserEntity
-            {
+            new() {
                 Id = Guid.NewGuid(),
                 FirstName = "FirstName1", LastName = "LastName",
                 DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat)
             },
-            new UserEntity
-            {
+            new() {
                 Id = Guid.NewGuid(),
                 FirstName = "FirstName2", LastName = "LastName",
                 DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat)
             },
-            new UserEntity
-            {
+            new() {
                 Id = userId,
                 FirstName = "FirstName3", LastName = "LastName",
                 DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat)
             },
-            new UserEntity
-            {
+            new() {
                 Id = Guid.NewGuid(),
                 FirstName = "FirstName3", LastName = "LastName",
                 DateOfBirth = DateTime.Parse("03/20/2012", UsCultureInfo.DateTimeFormat)
             },
-            new UserEntity
-            {
+            new() {
                 Id = Guid.NewGuid(),
                 FirstName = "FirstName5", LastName = "LastName",
                 DateOfBirth = DateTime.Parse("01/20/2018", UsCultureInfo.DateTimeFormat)
             }
         };
 
-        var mock = users.BuildMockDbSet();
-        mock.Setup(x => x.FindAsync(It.IsAny<object[]>())).ReturnsAsync((object[] ids) =>
-        {
-            var id = (Guid)ids.First();
-            return users.FirstOrDefault(x => x.Id == id);
-        });
-        var userRepository = new TestDbSetRepository(mock.Object);
+      var mock = users.BuildMockDbSet();
+      mock.Setup(x => x.FindAsync(It.IsAny<object[]>())).ReturnsAsync((object[] ids) =>
+      {
+        var id = (Guid)ids.First();
+        return users.FirstOrDefault(x => x.Id == id);
+      });
+      var userRepository = new TestDbSetRepository(mock.Object);
 
-        //act
-        var result = await ((DbSet<UserEntity>)userRepository.GetQueryable()).FindAsync(userId);
+      //act
+      var result = await ((DbSet<UserEntity>)userRepository.GetQueryable()).FindAsync(userId);
 
-        //assert
-        Assert.IsNotNull(result);
-        Assert.AreEqual("FirstName3", result.FirstName);
+      //assert
+      Assert.That(result, Is.Not.Null);
+      Assert.That("FirstName3", Is.EqualTo(result.FirstName));
     }
 
-        [TestCase]
+    [TestCase]
     public async Task DbSetGetAllUserEntitiesAsync()
     {
       // arrange
@@ -355,10 +345,10 @@ namespace MockQueryable.Sample
       var result = await userRepository.GetAllAsync().ToListAsync();
 
       // assert
-      Assert.AreEqual(users.Count, result.Count);
+      Assert.That(users.Count, Is.EqualTo(result.Count));
     }
-    
-    
+
+
     [TestCase]
     public async Task DbSetToListAsyncAsync_ShouldReturnAllEntities_WhenSourceIsChanged()
     {
@@ -373,8 +363,8 @@ namespace MockQueryable.Sample
       var result2 = await mockDbSet.Object.ToListAsync();
 
       // assert
-      Assert.AreEqual(0, result1.Count);
-      Assert.AreEqual(users.Count, result2.Count);
+      Assert.That(0, Is.EqualTo(result1.Count));
+      Assert.That(users.Count, Is.EqualTo(result2.Count));
     }
 
 
@@ -382,20 +372,20 @@ namespace MockQueryable.Sample
     [TestCase]
     public async Task DbSetCreatedFromCollectionGetAllUserEntitiesAsync()
     {
-        // arrange
-        var users = CreateUserList();
+      // arrange
+      var users = CreateUserList();
 
-        var mockDbSet = users.BuildMockDbSet();
-        var userRepository = new TestDbSetRepository(mockDbSet.Object);
+      var mockDbSet = users.BuildMockDbSet();
+      var userRepository = new TestDbSetRepository(mockDbSet.Object);
 
-        // act
-        var result = await userRepository.GetAllAsync().ToListAsync();
+      // act
+      var result = await userRepository.GetAllAsync().ToListAsync();
 
-        // assert
-        Assert.AreEqual(users.Count, result.Count);
+      // assert
+      Assert.That(users.Count, Is.EqualTo(result.Count));
     }
 
-        private static List<UserEntity> CreateUserList() => new List<UserEntity>
+    private static List<UserEntity> CreateUserList() => new()
     {
       new UserEntity { FirstName = "FirstName1", LastName = "LastName", DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat) },
       new UserEntity { FirstName = "FirstName2", LastName = "LastName", DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat) },

--- a/src/MockQueryable/MockQueryable.Sample/MyServiceNSubstituteTests.cs
+++ b/src/MockQueryable/MockQueryable.Sample/MyServiceNSubstituteTests.cs
@@ -9,336 +9,329 @@ using System.Threading.Tasks;
 
 namespace MockQueryable.Sample
 {
-    [TestFixture]
-    public class MyServiceNSubstituteTests
+  [TestFixture]
+  public class MyServiceNSubstituteTests
+  {
+    private static readonly CultureInfo UsCultureInfo = new("en-US");
+
+    [TestCase("AnyFirstName", "AnyExistLastName", "01/20/2012", "Users with DateOfBirth more than limit")]
+    [TestCase("ExistFirstName", "AnyExistLastName", "02/20/2012", "User with FirstName already exist")]
+    [TestCase("AnyFirstName", "ExistLastName", "01/20/2012", "User already exist")]
+    public void CreateUserIfNotExist(string firstName, string lastName, DateTime dateOfBirth, string expectedError)
     {
-        private static readonly CultureInfo UsCultureInfo = new CultureInfo("en-US");
+      //arrange
+      var userRepository = Substitute.For<IUserRepository>();
+      var service = new MyService(userRepository);
+      var users = new List<UserEntity>
+      {
+        new() {LastName = "ExistLastName", DateOfBirth = DateTime.Parse("01/20/2012",UsCultureInfo.DateTimeFormat)},
+        new() {FirstName = "ExistFirstName"},
+        new() {DateOfBirth = DateTime.Parse("01/20/2012",UsCultureInfo.DateTimeFormat)},
+        new() {DateOfBirth = DateTime.Parse("01/20/2012",UsCultureInfo.DateTimeFormat)},
+        new() {DateOfBirth = DateTime.Parse("01/20/2012",UsCultureInfo.DateTimeFormat)},
+      };
+      //expect
+      var mock = users.BuildMock();
+      userRepository.GetQueryable().Returns(mock);
+      //act
+      var ex = Assert.ThrowsAsync<ApplicationException>(() => service.CreateUserIfNotExist(firstName, lastName, dateOfBirth));
+      //assert
+      Assert.That(expectedError, Is.EqualTo(ex.Message));
 
+    }
 
-        [TestCase("AnyFirstName", "AnyExistLastName", "01/20/2012", "Users with DateOfBirth more than limit")]
-		[TestCase("ExistFirstName", "AnyExistLastName", "02/20/2012", "User with FirstName already exist")]
-		[TestCase("AnyFirstName", "ExistLastName", "01/20/2012", "User already exist")]
-		public void CreateUserIfNotExist(string firstName, string lastName, DateTime dateOfBirth, string expectedError)
-		{
-            //arrange
-		    var userRepository = Substitute.For<IUserRepository>();
-		    var service = new MyService(userRepository);
-            var users = new List<UserEntity>
-			{
-				new UserEntity{LastName = "ExistLastName", DateOfBirth = DateTime.Parse("01/20/2012",UsCultureInfo.DateTimeFormat)},
-				new UserEntity{FirstName = "ExistFirstName"},
-				new UserEntity{DateOfBirth = DateTime.Parse("01/20/2012",UsCultureInfo.DateTimeFormat)},
-				new UserEntity{DateOfBirth = DateTime.Parse("01/20/2012",UsCultureInfo.DateTimeFormat)},
-				new UserEntity{DateOfBirth = DateTime.Parse("01/20/2012",UsCultureInfo.DateTimeFormat)},
-			};
-			//expect
-			var mock = users.BuildMock();
-			userRepository.GetQueryable().Returns(mock);
-			//act
-			var ex= Assert.ThrowsAsync<ApplicationException>(() => service.CreateUserIfNotExist(firstName, lastName, dateOfBirth));
-			//assert
-			Assert.AreEqual(expectedError, ex.Message);
+    [TestCase("01/20/2012", "06/20/2018", 5)]
+    [TestCase("01/20/2012", "06/20/2012", 4)]
+    [TestCase("01/20/2012", "02/20/2012", 3)]
+    [TestCase("01/20/2010", "02/20/2011", 0)]
+    public async Task GetUserReports(DateTime from, DateTime to, int expectedCount)
+    {
+      //arrange
+      var userRepository = Substitute.For<IUserRepository>();
+      var service = new MyService(userRepository);
+      List<UserEntity> users = CreateUserList();
 
-		}
+      //expect
+      var mock = users.BuildMock();
+      userRepository.GetQueryable().Returns(mock);
+      //act
+      var result = await service.GetUserReports(from, to);
+      //assert
+      Assert.That(expectedCount, Is.EqualTo(result.Count));
+    }
 
-        [TestCase("01/20/2012", "06/20/2018",5)]
-		[TestCase("01/20/2012", "06/20/2012",4)]
-		[TestCase("01/20/2012", "02/20/2012",3)]
-		[TestCase("01/20/2010", "02/20/2011",0)]
-		public async Task GetUserReports(DateTime from, DateTime to, int expectedCount)
-		{
-            //arrange
-		    var userRepository = Substitute.For<IUserRepository>();
-		    var service = new MyService(userRepository);
-            List<UserEntity> users = CreateUserList();
+    [TestCase("01/20/2012", "06/20/2018", 5)]
+    [TestCase("01/20/2012", "06/20/2012", 4)]
+    [TestCase("01/20/2012", "02/20/2012", 3)]
+    [TestCase("01/20/2010", "02/20/2011", 0)]
+    public async Task GetUserReports_AutoMap(DateTime from, DateTime to, int expectedCount)
+    {
+      //arrange
+      List<UserEntity> users = CreateUserList();
 
-            //expect
-            var mock = users.BuildMock();
-			userRepository.GetQueryable().Returns(mock);
-			//act
-			var result = await service.GetUserReports(from, to);
-			//assert
-			Assert.AreEqual(expectedCount, result.Count);
-		}
+      var mock = users.AsQueryable().BuildMockDbSet();
+      var userRepository = new TestDbSetRepository(mock);
+      var service = new MyService(userRepository);
+      //act
+      var result = await service.GetUserReportsAutoMap(from, to);
+      //assert
+      Assert.That(expectedCount, Is.EqualTo(result.Count));
+    }
 
-        [TestCase("01/20/2012", "06/20/2018", 5)]
-        [TestCase("01/20/2012", "06/20/2012", 4)]
-        [TestCase("01/20/2012", "02/20/2012", 3)]
-        [TestCase("01/20/2010", "02/20/2011", 0)]
-        public async Task GetUserReports_AutoMap(DateTime from, DateTime to, int expectedCount)
-        {
-            //arrange
-            List<UserEntity> users = CreateUserList();
+    [TestCase("01/20/2012", "06/20/2018", 5)]
+    [TestCase("01/20/2012", "06/20/2012", 4)]
+    [TestCase("01/20/2012", "02/20/2012", 3)]
+    [TestCase("01/20/2010", "02/20/2011", 0)]
+    public async Task GetUserReports_AutoMap_FromDbSetCreatedFromCollection(DateTime from, DateTime to, int expectedCount)
+    {
+      //arrange
+      List<UserEntity> users = CreateUserList();
 
-            var mock = users.AsQueryable().BuildMockDbSet();
-            var userRepository = new TestDbSetRepository(mock);
-            var service = new MyService(userRepository);
-            //act
-            var result = await service.GetUserReportsAutoMap(from, to);
-            //assert
-            Assert.AreEqual(expectedCount, result.Count);
+      var mock = users.BuildMockDbSet();
+      var userRepository = new TestDbSetRepository(mock);
+      var service = new MyService(userRepository);
+      //act
+      var result = await service.GetUserReportsAutoMap(from, to);
+      //assert
+      Assert.That(expectedCount, Is.EqualTo(result.Count));
+    }
 
-        }
-
-        [TestCase("01/20/2012", "06/20/2018", 5)]
-        [TestCase("01/20/2012", "06/20/2012", 4)]
-        [TestCase("01/20/2012", "02/20/2012", 3)]
-        [TestCase("01/20/2010", "02/20/2011", 0)]
-        public async Task GetUserReports_AutoMap_FromDbSetCreatedFromCollection(DateTime from, DateTime to, int expectedCount)
-        {
-            //arrange
-            List<UserEntity> users = CreateUserList();
-
-            var mock = users.BuildMockDbSet();
-            var userRepository = new TestDbSetRepository(mock);
-            var service = new MyService(userRepository);
-            //act
-            var result = await service.GetUserReportsAutoMap(from, to);
-            //assert
-            Assert.AreEqual(expectedCount, result.Count);
-
-        }
-
-        [TestCase("AnyFirstName", "AnyExistLastName", "01/20/2012", "Users with DateOfBirth more than limit")]
-        [TestCase("ExistFirstName", "AnyExistLastName", "02/20/2012", "User with FirstName already exist")]
-        [TestCase("AnyFirstName", "ExistLastName", "01/20/2012", "User already exist")]
-        public void DbSetCreateUserIfNotExist(string firstName, string lastName, DateTime dateOfBirth, string expectedError)
-        {
-            //arrange
-            var users = new List<UserEntity>
+    [TestCase("AnyFirstName", "AnyExistLastName", "01/20/2012", "Users with DateOfBirth more than limit")]
+    [TestCase("ExistFirstName", "AnyExistLastName", "02/20/2012", "User with FirstName already exist")]
+    [TestCase("AnyFirstName", "ExistLastName", "01/20/2012", "User already exist")]
+    public void DbSetCreateUserIfNotExist(string firstName, string lastName, DateTime dateOfBirth, string expectedError)
+    {
+      //arrange
+      var users = new List<UserEntity>
             {
-                new UserEntity{LastName = "ExistLastName", DateOfBirth = DateTime.Parse("01/20/2012",UsCultureInfo.DateTimeFormat)},
-                new UserEntity{FirstName = "ExistFirstName"},
-                new UserEntity{DateOfBirth = DateTime.Parse("01/20/2012",UsCultureInfo.DateTimeFormat)},
-                new UserEntity{DateOfBirth = DateTime.Parse("01/20/2012",UsCultureInfo.DateTimeFormat)},
-                new UserEntity{DateOfBirth = DateTime.Parse("01/20/2012",UsCultureInfo.DateTimeFormat)},
+                new() {LastName = "ExistLastName", DateOfBirth = DateTime.Parse("01/20/2012",UsCultureInfo.DateTimeFormat)},
+                new() {FirstName = "ExistFirstName"},
+                new() {DateOfBirth = DateTime.Parse("01/20/2012",UsCultureInfo.DateTimeFormat)},
+                new() {DateOfBirth = DateTime.Parse("01/20/2012",UsCultureInfo.DateTimeFormat)},
+                new() {DateOfBirth = DateTime.Parse("01/20/2012",UsCultureInfo.DateTimeFormat)},
             };
-            var mock = users.AsQueryable().BuildMockDbSet();
-            var userRepository = new TestDbSetRepository(mock);
-            var service = new MyService(userRepository);
-            //act
-            var ex = Assert.ThrowsAsync<ApplicationException>(() => service.CreateUserIfNotExist(firstName, lastName, dateOfBirth));
-            //assert
-            Assert.AreEqual(expectedError, ex.Message);
+      var mock = users.AsQueryable().BuildMockDbSet();
+      var userRepository = new TestDbSetRepository(mock);
+      var service = new MyService(userRepository);
+      //act
+      var ex = Assert.ThrowsAsync<ApplicationException>(() => service.CreateUserIfNotExist(firstName, lastName, dateOfBirth));
+      //assert
+      Assert.That(expectedError, Is.EqualTo(ex.Message));
+    }
 
-        }
-
-
-        [TestCase("AnyFirstName", "AnyExistLastName", "01/20/2012", "Users with DateOfBirth more than limit")]
-        [TestCase("ExistFirstName", "AnyExistLastName", "02/20/2012", "User with FirstName already exist")]
-        [TestCase("AnyFirstName", "ExistLastName", "01/20/2012", "User already exist")]
-        public void DbSetCreatedFromCollectionCreateUserIfNotExist(string firstName, string lastName, DateTime dateOfBirth, string expectedError)
-        {
-            //arrange
-            var users = new List<UserEntity>
+    [TestCase("AnyFirstName", "AnyExistLastName", "01/20/2012", "Users with DateOfBirth more than limit")]
+    [TestCase("ExistFirstName", "AnyExistLastName", "02/20/2012", "User with FirstName already exist")]
+    [TestCase("AnyFirstName", "ExistLastName", "01/20/2012", "User already exist")]
+    public void DbSetCreatedFromCollectionCreateUserIfNotExist(string firstName, string lastName, DateTime dateOfBirth, string expectedError)
+    {
+      //arrange
+      var users = new List<UserEntity>
             {
-                new UserEntity{LastName = "ExistLastName", DateOfBirth = DateTime.Parse("01/20/2012",UsCultureInfo.DateTimeFormat)},
-                new UserEntity{FirstName = "ExistFirstName"},
-                new UserEntity{DateOfBirth = DateTime.Parse("01/20/2012",UsCultureInfo.DateTimeFormat)},
-                new UserEntity{DateOfBirth = DateTime.Parse("01/20/2012",UsCultureInfo.DateTimeFormat)},
-                new UserEntity{DateOfBirth = DateTime.Parse("01/20/2012",UsCultureInfo.DateTimeFormat)},
+                new() {LastName = "ExistLastName", DateOfBirth = DateTime.Parse("01/20/2012",UsCultureInfo.DateTimeFormat)},
+                new() {FirstName = "ExistFirstName"},
+                new() {DateOfBirth = DateTime.Parse("01/20/2012",UsCultureInfo.DateTimeFormat)},
+                new() {DateOfBirth = DateTime.Parse("01/20/2012",UsCultureInfo.DateTimeFormat)},
+                new() {DateOfBirth = DateTime.Parse("01/20/2012",UsCultureInfo.DateTimeFormat)},
             };
-            var mock = users.BuildMockDbSet();
-            var userRepository = new TestDbSetRepository(mock);
-            var service = new MyService(userRepository);
-            //act
-            var ex = Assert.ThrowsAsync<ApplicationException>(() => service.CreateUserIfNotExist(firstName, lastName, dateOfBirth));
-            //assert
-            Assert.AreEqual(expectedError, ex.Message);
+      var mock = users.BuildMockDbSet();
+      var userRepository = new TestDbSetRepository(mock);
+      var service = new MyService(userRepository);
+      //act
+      var ex = Assert.ThrowsAsync<ApplicationException>(() => service.CreateUserIfNotExist(firstName, lastName, dateOfBirth));
+      //assert
+      Assert.That(expectedError, Is.EqualTo(ex.Message));
+    }
 
-        }
+    [TestCase("AnyFirstName", "ExistLastName", "01/20/2012")]
+    public async Task DbSetCreateUser(string firstName, string lastName, DateTime dateOfBirth)
+    {
+      //arrange
+      var userEntities = new List<UserEntity>();
+      var mock = userEntities.AsQueryable().BuildMockDbSet();
+      mock.AddAsync(Arg.Any<UserEntity>())
+          .Returns(info => null)
+          .AndDoes(info => userEntities.Add(info.Arg<UserEntity>()));
+      var userRepository = new TestDbSetRepository(mock);
+      var service = new MyService(userRepository);
+      //act
+      await service.CreateUserIfNotExist(firstName, lastName, dateOfBirth);
+      // assert
+      var entity = mock.Single();
+      Assert.That(firstName, Is.EqualTo(entity.FirstName));
+      Assert.That(lastName, Is.EqualTo(entity.LastName));
+      Assert.That(dateOfBirth, Is.EqualTo(entity.DateOfBirth));
+    }
 
-        [TestCase("AnyFirstName", "ExistLastName", "01/20/2012")]
-        public async Task DbSetCreateUser(string firstName, string lastName, DateTime dateOfBirth)
-        {
-            //arrange
-            var userEntities = new List<UserEntity>();
-            var mock = userEntities.AsQueryable().BuildMockDbSet();
-            mock.AddAsync(Arg.Any<UserEntity>())
-                .Returns(info => null)
-                .AndDoes(info => userEntities.Add(info.Arg<UserEntity>()));
-            var userRepository = new TestDbSetRepository(mock);
-            var service = new MyService(userRepository);
-            //act
-            await service.CreateUserIfNotExist(firstName, lastName, dateOfBirth);
-            // assert
-            var entity = mock.Single();
-            Assert.AreEqual(firstName, entity.FirstName);
-            Assert.AreEqual(lastName, entity.LastName);
-            Assert.AreEqual(dateOfBirth, entity.DateOfBirth);
-        }
+    [TestCase("AnyFirstName", "ExistLastName", "01/20/2012")]
+    public async Task DbSetCreatedFromCollectionCreateUser(string firstName, string lastName, DateTime dateOfBirth)
+    {
+      //arrange
+      var userEntities = new List<UserEntity>();
+      var mock = userEntities.BuildMockDbSet();
+      mock.AddAsync(Arg.Any<UserEntity>())
+          .Returns(info => null)
+          .AndDoes(info => userEntities.Add(info.Arg<UserEntity>()));
+      var userRepository = new TestDbSetRepository(mock);
+      var service = new MyService(userRepository);
+      //act
+      await service.CreateUserIfNotExist(firstName, lastName, dateOfBirth);
+      // assert
+      var entity = mock.Single();
+      Assert.That(firstName, Is.EqualTo(entity.FirstName));
+      Assert.That(lastName, Is.EqualTo(entity.LastName));
+      Assert.That(dateOfBirth, Is.EqualTo(entity.DateOfBirth));
+    }
 
-        [TestCase("AnyFirstName", "ExistLastName", "01/20/2012")]
-        public async Task DbSetCreatedFromCollectionCreateUser(string firstName, string lastName, DateTime dateOfBirth)
-        {
-            //arrange
-            var userEntities = new List<UserEntity>();
-            var mock = userEntities.BuildMockDbSet();
-            mock.AddAsync(Arg.Any<UserEntity>())
-                .Returns(info => null)
-                .AndDoes(info => userEntities.Add(info.Arg<UserEntity>()));
-            var userRepository = new TestDbSetRepository(mock);
-            var service = new MyService(userRepository);
-            //act
-            await service.CreateUserIfNotExist(firstName, lastName, dateOfBirth);
-            // assert
-            var entity = mock.Single();
-            Assert.AreEqual(firstName, entity.FirstName);
-            Assert.AreEqual(lastName, entity.LastName);
-            Assert.AreEqual(dateOfBirth, entity.DateOfBirth);
-        }
+    [TestCase("01/20/2012", "06/20/2018", 5)]
+    [TestCase("01/20/2012", "06/20/2012", 4)]
+    [TestCase("01/20/2012", "02/20/2012", 3)]
+    [TestCase("01/20/2010", "02/20/2011", 0)]
+    public async Task DbSetGetUserReports(DateTime from, DateTime to, int expectedCount)
+    {
+      //arrange
+      var users = CreateUserList();
 
-        [TestCase("01/20/2012", "06/20/2018", 5)]
-        [TestCase("01/20/2012", "06/20/2012", 4)]
-        [TestCase("01/20/2012", "02/20/2012", 3)]
-        [TestCase("01/20/2010", "02/20/2011", 0)]
-        public async Task DbSetGetUserReports(DateTime from, DateTime to, int expectedCount)
-        {
-            //arrange
-            var users = CreateUserList();
+      var mock = users.AsQueryable().BuildMockDbSet();
+      var userRepository = new TestDbSetRepository(mock);
+      var service = new MyService(userRepository);
+      //act
+      var result = await service.GetUserReports(from, to);
+      //assert
+      Assert.That(expectedCount, Is.EqualTo(result.Count));
+    }
 
-            var mock = users.AsQueryable().BuildMockDbSet();
-            var userRepository = new TestDbSetRepository(mock);
-            var service = new MyService(userRepository);
-            //act
-            var result = await service.GetUserReports(from, to);
-            //assert
-            Assert.AreEqual(expectedCount, result.Count);
-        }
+    [TestCase("01/20/2012", "06/20/2018", 5)]
+    [TestCase("01/20/2012", "06/20/2012", 4)]
+    [TestCase("01/20/2012", "02/20/2012", 3)]
+    [TestCase("01/20/2010", "02/20/2011", 0)]
+    public async Task DbSetCreatedFromCollectionGetUserReports(DateTime from, DateTime to, int expectedCount)
+    {
+      //arrange
+      var users = CreateUserList();
 
-        [TestCase("01/20/2012", "06/20/2018", 5)]
-        [TestCase("01/20/2012", "06/20/2012", 4)]
-        [TestCase("01/20/2012", "02/20/2012", 3)]
-        [TestCase("01/20/2010", "02/20/2011", 0)]
-        public async Task DbSetCreatedFromCollectionGetUserReports(DateTime from, DateTime to, int expectedCount)
-        {
-            //arrange
-            var users = CreateUserList();
+      var mock = users.BuildMockDbSet();
+      var userRepository = new TestDbSetRepository(mock);
+      var service = new MyService(userRepository);
+      //act
+      var result = await service.GetUserReports(from, to);
+      //assert
+      Assert.That(expectedCount, Is.EqualTo(result.Count));
+    }
 
-            var mock = users.BuildMockDbSet();
-            var userRepository = new TestDbSetRepository(mock);
-            var service = new MyService(userRepository);
-            //act
-            var result = await service.GetUserReports(from, to);
-            //assert
-            Assert.AreEqual(expectedCount, result.Count);
-        }
+    [TestCase]
+    public async Task DbSetGetAllUserEntity()
+    {
+      //arrange
+      var users = CreateUserList();
+      var mock = users.AsQueryable().BuildMockDbSet();
+      var userRepository = new TestDbSetRepository(mock);
+      //act
+      var result = await userRepository.GetAll();
+      //assert
+      Assert.That(users.Count, Is.EqualTo(result.Count));
+    }
 
-        [TestCase]
-        public async Task DbSetGetAllUserEntity()
-        {
-            //arrange
-            var users = CreateUserList();
-            var mock = users.AsQueryable().BuildMockDbSet();
-            var userRepository = new TestDbSetRepository(mock);
-            //act
-            var result = await userRepository.GetAll();
-            //assert
-            Assert.AreEqual(users.Count, result.Count);
-        }
+    [TestCase]
+    public async Task DbSetCreatedFromCollectionGetAllUserEntity()
+    {
+      //arrange
+      var users = CreateUserList();
+      var mock = users.BuildMockDbSet();
+      var userRepository = new TestDbSetRepository(mock);
+      //act
+      var result = await userRepository.GetAll();
+      //assert
+      Assert.That(users.Count, Is.EqualTo(result.Count));
+    }
 
-        [TestCase]
-        public async Task DbSetCreatedFromCollectionGetAllUserEntity()
-        {
-            //arrange
-            var users = CreateUserList();
-            var mock = users.BuildMockDbSet();
-            var userRepository = new TestDbSetRepository(mock);
-            //act
-            var result = await userRepository.GetAll();
-            //assert
-            Assert.AreEqual(users.Count, result.Count);
-        }
+    [TestCase]
+    public async Task DbSetGetAllUserEntitiesAsync()
+    {
+      // arrange
+      var users = CreateUserList();
 
-        [TestCase]
-        public async Task DbSetGetAllUserEntitiesAsync()
-        {
-            // arrange
-            var users = CreateUserList();
+      var mockDbSet = users.AsQueryable().BuildMockDbSet();
+      var userRepository = new TestDbSetRepository(mockDbSet);
 
-            var mockDbSet = users.AsQueryable().BuildMockDbSet();
-            var userRepository = new TestDbSetRepository(mockDbSet);
+      // act
+      var result = await userRepository.GetAllAsync().ToListAsync();
 
-            // act
-            var result = await userRepository.GetAllAsync().ToListAsync();
+      // assert
+      Assert.That(users.Count, Is.EqualTo(result.Count));
+    }
 
-            // assert
-            Assert.AreEqual(users.Count, result.Count);
-        }
-        
-        
-        [TestCase]
-        public async Task DbSetGetAllUserEntitiesAsync_ShouldReturnAllEntities_WhenSourceIsChanged()
-        {
-	        // arrange
-	        var users = new List<UserEntity>();
+    [TestCase]
+    public async Task DbSetGetAllUserEntitiesAsync_ShouldReturnAllEntities_WhenSourceIsChanged()
+    {
+      // arrange
+      var users = new List<UserEntity>();
 
-	        var mockDbSet = users.AsQueryable().BuildMockDbSet();
-	        var userRepository = new TestDbSetRepository(mockDbSet);
+      var mockDbSet = users.AsQueryable().BuildMockDbSet();
+      var userRepository = new TestDbSetRepository(mockDbSet);
 
-	        // act
-	        var result1 = await userRepository.GetAllAsync().ToListAsync();
-	        users.AddRange(CreateUserList());
-	        var result2 = await userRepository.GetAllAsync().ToListAsync();
+      // act
+      var result1 = await userRepository.GetAllAsync().ToListAsync();
+      users.AddRange(CreateUserList());
+      var result2 = await userRepository.GetAllAsync().ToListAsync();
 
-	        // assert
-	        Assert.AreEqual(0, result1.Count);
-	        Assert.AreEqual(users.Count, result2.Count);
-        }
+      // assert
+      Assert.That(0, Is.EqualTo(result1.Count));
+      Assert.That(users.Count, Is.EqualTo(result2.Count));
+    }
 
-        [TestCase]
-        public async Task DbSetCreatedFromCollectionGetAllUserEntitiesAsync()
-        {
-            // arrange
-            var users = CreateUserList();
+    [TestCase]
+    public async Task DbSetCreatedFromCollectionGetAllUserEntitiesAsync()
+    {
+      // arrange
+      var users = CreateUserList();
 
-            var mockDbSet = users.BuildMockDbSet();
-            var userRepository = new TestDbSetRepository(mockDbSet);
+      var mockDbSet = users.BuildMockDbSet();
+      var userRepository = new TestDbSetRepository(mockDbSet);
 
-            // act
-            var result = await userRepository.GetAllAsync().ToListAsync();
+      // act
+      var result = await userRepository.GetAllAsync().ToListAsync();
 
-            // assert
-            Assert.AreEqual(users.Count, result.Count);
-        }
+      // assert
+      Assert.That(users.Count, Is.EqualTo(result.Count));
+    }
 
-        [TestCase]
-        public async Task DbSetGetOneUserTntityAsync()
-        {
-            // arrange
-            var users = CreateUserList();
+    [TestCase]
+    public async Task DbSetGetOneUserTntityAsync()
+    {
+      // arrange
+      var users = CreateUserList();
 
-            var mockDbSet = users.AsQueryable().BuildMockDbSet();
-            var userRepository = new TestDbSetRepository(mockDbSet);
+      var mockDbSet = users.AsQueryable().BuildMockDbSet();
+      var userRepository = new TestDbSetRepository(mockDbSet);
 
-            // act
-            var result = await userRepository.GetAllAsync()
-                .Where(user => user.FirstName == "FirstName1")
-                .FirstOrDefaultAsync();
+      // act
+      var result = await userRepository.GetAllAsync()
+          .Where(user => user.FirstName == "FirstName1")
+          .FirstOrDefaultAsync();
 
-            // assert
-            Assert.AreEqual(users.First(), result);
-        }
+      // assert
+      Assert.That(users.First(), Is.EqualTo(result));
+    }
 
-        [TestCase]
-        public async Task DbSetCreatedFromCollectionGetOneUserTntityAsync()
-        {
-            // arrange
-            var users = CreateUserList();
+    [TestCase]
+    public async Task DbSetCreatedFromCollectionGetOneUserTntityAsync()
+    {
+      // arrange
+      var users = CreateUserList();
 
-            var mockDbSet = users.BuildMockDbSet();
-            var userRepository = new TestDbSetRepository(mockDbSet);
+      var mockDbSet = users.BuildMockDbSet();
+      var userRepository = new TestDbSetRepository(mockDbSet);
 
-            // act
-            var result = await userRepository.GetAllAsync()
-                                             .Where(user => user.FirstName == "FirstName1")
-                                             .FirstOrDefaultAsync();
+      // act
+      var result = await userRepository.GetAllAsync()
+                                       .Where(user => user.FirstName == "FirstName1")
+                                       .FirstOrDefaultAsync();
 
-            // assert
-            Assert.AreEqual(users.First(), result);
-        }
+      // assert
+      Assert.That(users.First(), Is.EqualTo(result));
+    }
 
-        private static List<UserEntity> CreateUserList() => new List<UserEntity>
+    private static List<UserEntity> CreateUserList() => new()
         {
             new UserEntity { FirstName = "FirstName1", LastName = "LastName", DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat) },
             new UserEntity { FirstName = "FirstName2", LastName = "LastName", DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat) },
@@ -346,6 +339,5 @@ namespace MockQueryable.Sample
             new UserEntity { FirstName = "FirstName3", LastName = "LastName", DateOfBirth = DateTime.Parse("03/20/2012", UsCultureInfo.DateTimeFormat) },
             new UserEntity { FirstName = "FirstName5", LastName = "LastName", DateOfBirth = DateTime.Parse("01/20/2018", UsCultureInfo.DateTimeFormat) },
         };
-
-    }
+  }
 }

--- a/src/MockQueryable/MockQueryable.Sample/MyServiceNSubstituteTests.cs
+++ b/src/MockQueryable/MockQueryable.Sample/MyServiceNSubstituteTests.cs
@@ -37,7 +37,6 @@ namespace MockQueryable.Sample
       var ex = Assert.ThrowsAsync<ApplicationException>(() => service.CreateUserIfNotExist(firstName, lastName, dateOfBirth));
       //assert
       Assert.That(expectedError, Is.EqualTo(ex.Message));
-
     }
 
     [TestCase("01/20/2012", "06/20/2018", 5)]
@@ -329,6 +328,43 @@ namespace MockQueryable.Sample
 
       // assert
       Assert.That(users.First(), Is.EqualTo(result));
+    }
+
+    [TestCase]
+    public void GetUsersByFirstName_ExpressionVisitorMissing_ThrowsException()
+    {
+      // arrange
+      var users = CreateUserList();
+
+      var mockDbSet = users.AsQueryable().BuildMockDbSet();
+      var userRepository = new TestDbSetRepository(mockDbSet);
+
+      // act
+      var exception = Assert.ThrowsAsync<InvalidOperationException>(() => userRepository.GetUsersByFirstName("naME"));
+
+      // assert
+      Assert.That(
+        exception.Message,
+        Is.EqualTo(
+          "The 'ILike' method is not supported because the query has switched to client-evaluation. " +
+          "This usually happens when the arguments to the method cannot be translated to server. " +
+          "Rewrite the query to avoid client evaluation of arguments so that method can be translated to server."));
+    }
+
+    [TestCase]
+    public async Task GetUsersByFirstName_PartOfNameCaseInsensitiveSearch_AllMatchesReturned()
+    {
+      // arrange
+      var users = CreateUserList();
+
+      var mockDbSet = users.AsQueryable().BuildMockDbSet<UserEntity, SampleILikeExpressionVisitor>();
+      var userRepository = new TestDbSetRepository(mockDbSet);
+
+      // act
+      var result = await userRepository.GetUsersByFirstName("naME");
+
+      // assert
+      Assert.That(users.Count, Is.EqualTo(result.Count()));
     }
 
     private static List<UserEntity> CreateUserList() => new()

--- a/src/MockQueryable/MockQueryable.Sample/SampleILikeExpressionVisitor .cs
+++ b/src/MockQueryable/MockQueryable.Sample/SampleILikeExpressionVisitor .cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.EntityFrameworkCore;
+using System;
+using System.Linq.Expressions;
+
+namespace MockQueryable.Sample
+{
+  public class SampleILikeExpressionVisitor : ExpressionVisitor
+  {
+    private static readonly char[] value = ['%'];
+
+    /// <summary>
+    /// Rewrites the ILike method call to a string.Contains call with a trimmed
+    /// and lowercased pattern.
+    /// This is used to simulate the behavior of ILike in PostgreSQL, which is
+    /// case-insensitive and allows for wildcard matching with '%'.
+    /// </summary>
+    protected override Expression VisitMethodCall(MethodCallExpression node)
+    {
+      if (node.Method.Name != nameof(NpgsqlDbFunctionsExtensions.ILike) ||
+          node.Arguments.Count != 3)
+      {
+        return base.VisitMethodCall(node);
+      }
+
+      var stringExpression = node.Arguments[1];
+      var patternExpression = node.Arguments[2];
+
+      var toLowerPattern = Expression.Call(patternExpression, nameof(string.ToLower), Type.EmptyTypes);
+      var trimMethod = typeof(string).GetMethod(nameof(string.Trim), [typeof(char[])]);
+      var trimmedPattern = Expression.Call(toLowerPattern, trimMethod!, Expression.Constant(value));
+
+      return Expression.Call(
+          Expression.Call(stringExpression, nameof(string.ToLower), Type.EmptyTypes),
+          nameof(string.Contains),
+          Type.EmptyTypes,
+          trimmedPattern
+      );
+    }
+  }
+}

--- a/src/MockQueryable/MockQueryable.Sample/TestDbSetRepository.cs
+++ b/src/MockQueryable/MockQueryable.Sample/TestDbSetRepository.cs
@@ -5,31 +5,40 @@ using System.Threading.Tasks;
 
 namespace MockQueryable.Sample
 {
-    public class TestDbSetRepository : IUserRepository
+  public class TestDbSetRepository : IUserRepository
+  {
+    private readonly DbSet<UserEntity> _dbSet;
+
+    public TestDbSetRepository(DbSet<UserEntity> dbSet)
     {
-        private readonly DbSet<UserEntity> _dbSet;
-
-        public TestDbSetRepository(DbSet<UserEntity> dbSet)
-        {
-            _dbSet = dbSet;
-        }
-        public IQueryable<UserEntity> GetQueryable()
-        {
-            return _dbSet;
-        }
-
-        public async Task CreateUser(UserEntity user)
-        {
-            await _dbSet.AddAsync(user);
-        }
-
-        public async Task<List<UserEntity>> GetAll() {
-            return await _dbSet.ToListAsync();
-        }
-
-        public IAsyncEnumerable<UserEntity> GetAllAsync()
-        {
-            return _dbSet.AsAsyncEnumerable();
-        }
+      _dbSet = dbSet;
     }
+
+    public IQueryable<UserEntity> GetQueryable()
+    {
+      return _dbSet;
+    }
+
+    public async Task CreateUser(UserEntity user)
+    {
+      await _dbSet.AddAsync(user);
+    }
+
+    public async Task<List<UserEntity>> GetAll()
+    {
+      return await _dbSet.ToListAsync();
+    }
+
+    public IAsyncEnumerable<UserEntity> GetAllAsync()
+    {
+      return _dbSet.AsAsyncEnumerable();
+    }
+
+    public async Task<IEnumerable<UserEntity>> GetUsersByFirstName(string firstName)
+    {
+      return await _dbSet
+        .Where(x => EF.Functions.ILike(x.FirstName, $"%{firstName}%"))
+        .ToListAsync();
+    }
+  }
 }


### PR DESCRIPTION
# PR Details

- Update all NuGet packages
- Upgrade .NET version from 6 to 8
- New feature: Support for custom `ExpressionVisitor`

## Description

### Update all NuGet packages
All NuGet packages have been updated to their latest versions. The most significant change was upgrading the AutoMapper library from 8.0.0 to 15.0.1. The code was adjusted for compatibility with the new version, while maintaining previous behavior.

### Upgrade .NET version from 6 to 8
Upgrading to .NET 8 was necessary to ensure compatibility with the latest NuGet packages.

### New feature: Support for custom `ExpressionVisitor`
A new overload for `BuildMockDbSet` allows consumers to define and pass a custom `ExpressionVisitor`. This enables scenarios such as mocking expressions like `EF.Functions.ILike` and more. The new generic parameter `TExpressionVisitor` makes this possible.

This approach is intentionally flexible, rather than implementing a fake for each `EF.Function`, as there are many possible functions and covering every use case is not feasible.

## Related Issue

Update of packages:
https://github.com/romantitov/MockQueryable/issues/82

Custom ExpressionVisitor:
https://github.com/romantitov/MockQueryable/issues/73

## How Has This Been Tested

- Created new unit tests for all three variants to ensure the feature is working as expected, additionally using a sample implementation for a new visitor mocking `EF.Functions.ILike` (see `SampleILikeExpressionVisitor`)
- Created an overload of the public methods to keep the existing usages unaffetced.
- Ensured all new unit tests passed and that existing tests remained unaffected.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
