### PR TITLE
#66: Adjust test data set for `ExecuteUpdate` and `ExecuteDelete`

### DIFF
--- a/src/MockQueryable/MockQueryable.Core/TestQueryProvider.cs
+++ b/src/MockQueryable/MockQueryable.Core/TestQueryProvider.cs
@@ -6,80 +6,81 @@ using System.Linq.Expressions;
 
 namespace MockQueryable.Core
 {
-    public abstract class TestQueryProvider<T> : IOrderedQueryable<T>, IQueryProvider
+  public abstract class TestQueryProvider<T> : IOrderedQueryable<T>, IQueryProvider
+  {
+    private IEnumerable<T> _enumerable;
+    private readonly Action<T> _optionalRemoveCallback;
+
+    protected TestQueryProvider(Expression expression)
+    {
+      Expression = expression;
+    }
+
+    protected TestQueryProvider(IEnumerable<T> enumerable, Action<T> optionalRemoveCallback)
+    {
+      _enumerable = enumerable;
+      Expression = enumerable.AsQueryable().Expression;
+      _optionalRemoveCallback = optionalRemoveCallback;
+    }
+
+    public IQueryable CreateQuery(Expression expression)
+    {
+      if (expression is MethodCallExpression m)
+      {
+        var resultType = m.Method.ReturnType; // it should be IQueryable<T>
+        var tElement = resultType.GetGenericArguments().First();
+        return (IQueryable)CreateInstance(tElement, expression);
+      }
+
+      return CreateQuery<T>(expression);
+    }
+
+    public IQueryable<TEntity> CreateQuery<TEntity>(Expression expression)
+    {
+      return (IQueryable<TEntity>)CreateInstance(typeof(TEntity), expression);
+    }
+
+    private object CreateInstance(Type tElement, Expression expression)
+    {
+      var queryType = GetType().GetGenericTypeDefinition().MakeGenericType(tElement);
+      return Activator.CreateInstance(queryType, expression, _optionalRemoveCallback);
+    }
+
+    public object Execute(Expression expression)
+    {
+      return CompileExpressionItem<object>(expression);
+    }
+
+    public virtual TResult Execute<TResult>(Expression expression)
     {
 
-        private IEnumerable<T> _enumerable;
-
-        protected TestQueryProvider(Expression expression)
-        {
-            Expression = expression;
-        }
-
-        protected TestQueryProvider(IEnumerable<T> enumerable)
-        {
-            _enumerable = enumerable;
-            Expression = enumerable.AsQueryable().Expression;
-        }
-
-        public IQueryable CreateQuery(Expression expression)
-        {
-            if (expression is MethodCallExpression m)
-            {
-                var resultType = m.Method.ReturnType; // it should be IQueryable<T>
-                var tElement = resultType.GetGenericArguments().First();
-                return (IQueryable) CreateInstance(tElement, expression);
-            }
-
-            return CreateQuery<T>(expression);
-        }
-
-        public IQueryable<TEntity> CreateQuery<TEntity>(Expression expression)
-        {
-            return (IQueryable<TEntity>) CreateInstance(typeof(TEntity), expression);
-        }
-
-        private object CreateInstance(Type tElement, Expression expression)
-        {
-            var queryType = GetType().GetGenericTypeDefinition().MakeGenericType(tElement);
-            return Activator.CreateInstance(queryType, expression);
-        }
-
-        public object Execute(Expression expression)
-        {
-            return CompileExpressionItem<object>(expression);
-        }
-
-        public virtual TResult Execute<TResult>(Expression expression)
-        {
-
-            return CompileExpressionItem<TResult>(expression);
-        }
-
-        IEnumerator<T> IEnumerable<T>.GetEnumerator()
-        {
-            if (_enumerable == null) _enumerable = CompileExpressionItem<IEnumerable<T>>(Expression);
-            return _enumerable.GetEnumerator();
-        }
-
-        IEnumerator IEnumerable.GetEnumerator()
-        {
-            if (_enumerable == null) _enumerable = CompileExpressionItem<IEnumerable<T>>(Expression);
-            return _enumerable.GetEnumerator();
-        }
-
-        public Type ElementType => typeof(T);
-
-        public Expression Expression { get; }
-
-        public IQueryProvider Provider => this;
-
-        protected static TResult CompileExpressionItem<TResult>(Expression expression)
-        {
-            var visitor = new TestExpressionVisitor();
-            var body = visitor.Visit(expression);
-            var f = Expression.Lambda<Func<TResult>>(body ?? throw new InvalidOperationException($"{nameof(body)} is null"), (IEnumerable<ParameterExpression>) null);
-            return f.Compile()();
-        }
+      return CompileExpressionItem<TResult>(expression);
     }
+
+    IEnumerator<T> IEnumerable<T>.GetEnumerator()
+    {
+      if (_enumerable == null) _enumerable = CompileExpressionItem<IEnumerable<T>>(Expression);
+      return _enumerable.GetEnumerator();
+    }
+
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+      if (_enumerable == null) _enumerable = CompileExpressionItem<IEnumerable<T>>(Expression);
+      return _enumerable.GetEnumerator();
+    }
+
+    public Type ElementType => typeof(T);
+
+    public Expression Expression { get; }
+
+    public IQueryProvider Provider => this;
+
+    protected static TResult CompileExpressionItem<TResult>(Expression expression)
+    {
+      var visitor = new TestExpressionVisitor();
+      var body = visitor.Visit(expression);
+      var f = Expression.Lambda<Func<TResult>>(body ?? throw new InvalidOperationException($"{nameof(body)} is null"), (IEnumerable<ParameterExpression>)null);
+      return f.Compile()();
+    }
+  }
 }

--- a/src/MockQueryable/MockQueryable.EntityFrameworkCore/MockQueryableExtensions.cs
+++ b/src/MockQueryable/MockQueryable.EntityFrameworkCore/MockQueryableExtensions.cs
@@ -9,11 +9,11 @@ using System.Linq;
 // is dependent on the EF Core AsyncEnumerable.
 namespace MockQueryable
 {
-    public static class MockQueryableExtensions
+  public static class MockQueryableExtensions
+  {
+    public static IQueryable<TEntity> BuildMock<TEntity>(this IEnumerable<TEntity> data) where TEntity : class
     {
-        public static IQueryable<TEntity> BuildMock<TEntity>(this IEnumerable<TEntity> data) where TEntity : class
-        {
-            return new TestAsyncEnumerableEfCore<TEntity>(data);
-        }
+      return new TestAsyncEnumerableEfCore<TEntity>(data);
     }
+  }
 }

--- a/src/MockQueryable/MockQueryable.EntityFrameworkCore/TestQueryProviderEfCore.cs
+++ b/src/MockQueryable/MockQueryable.EntityFrameworkCore/TestQueryProviderEfCore.cs
@@ -1,25 +1,30 @@
-﻿using System.Collections.Generic;
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Query;
+using MockQueryable.Core;
+using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Query;
-using MockQueryable.Core;
 
 namespace MockQueryable.EntityFrameworkCore
 {
-  public class TestAsyncEnumerableEfCore<T>: TestQueryProvider<T>, IAsyncEnumerable<T>, IAsyncQueryProvider
+  public class TestAsyncEnumerableEfCore<T> : TestQueryProvider<T>, IAsyncEnumerable<T>, IAsyncQueryProvider
   {
-    public TestAsyncEnumerableEfCore(Expression expression) : base(expression)
+    private readonly Action<T> _optionalRemoveCallback;
+
+    public TestAsyncEnumerableEfCore(Expression expression, Action<T> optionalRemoveCallback = null) : base(expression)
     {
+      _optionalRemoveCallback = optionalRemoveCallback;
     }
 
-    public TestAsyncEnumerableEfCore(IEnumerable<T> enumerable) : base(enumerable)
+    public TestAsyncEnumerableEfCore(IEnumerable<T> enumerable, Action<T> optionalRemoveCallback = null) : base(enumerable, optionalRemoveCallback)
     {
+      _optionalRemoveCallback = optionalRemoveCallback;
     }
 
-    public TResult ExecuteAsync<TResult>(Expression expression, CancellationToken cancellationToken)
+    public TResult ExecuteAsync<TResult>(Expression expression, CancellationToken cancellationToken = default)
     {
       var expectedResultType = typeof(TResult).GetGenericArguments()[0];
       var executionResult = typeof(IQueryProvider)
@@ -35,22 +40,64 @@ namespace MockQueryable.EntityFrameworkCore
 
     public override TResult Execute<TResult>(Expression expression)
     {
-        if (expression is MethodCallExpression methodCall && (methodCall.Method.Name == nameof(RelationalQueryableExtensions.ExecuteUpdate) || methodCall.Method.Name == nameof(RelationalQueryableExtensions.ExecuteDelete) )
-                                                          && typeof(TResult) == typeof(int))
+      // Intercept ExecuteDelete and ExecuteUpdate calls
+      if (expression is MethodCallExpression methodCall &&
+        (methodCall.Method.Name == nameof(RelationalQueryableExtensions.ExecuteUpdate) || methodCall.Method.Name == nameof(RelationalQueryableExtensions.ExecuteDelete)) &&
+        typeof(TResult) == typeof(int))
+      {
+        var affectedItems = base.Execute<IEnumerable<T>>(Expression).ToList();
+
+        if (methodCall.Method.Name == nameof(RelationalQueryableExtensions.ExecuteUpdate))
         {
-            // Intercept ExecuteDelete and ExecuteUpdate calls
-            var affectedItems = base.Execute<IEnumerable<T>>(Expression).ToList();
-         
-            // Return the count of affected items
-            return (TResult)(object)affectedItems.Count;
+          ApplyUpdateChangesToDbSet(affectedItems, methodCall);
         }
-        // Fall back to default expression execution
-        return base.Execute<TResult>(expression);
+
+        if (methodCall.Method.Name == nameof(RelationalQueryableExtensions.ExecuteDelete))
+        {
+          foreach (var item in affectedItems)
+          {
+            _optionalRemoveCallback?.Invoke(item);
+          }
+        }
+
+        // Return the count of affected items
+        return (TResult)(object)affectedItems.Count;
+      }
+      // Fall back to default expression execution
+      return base.Execute<TResult>(expression);
     }
 
     public IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default)
     {
       return new TestAsyncEnumerator<T>(this.AsEnumerable().GetEnumerator());
+    }
+
+    private static void ApplyUpdateChangesToDbSet(IEnumerable<T> affectedItems, MethodCallExpression methodCallExpression)
+    {
+      // Extract the update lambda: opt => opt.SetProperty(...)
+      if ((methodCallExpression.Arguments[1] as UnaryExpression)?.Operand is not LambdaExpression updateLambda)
+      {
+        return;
+      }
+
+      // The body may be a chain of MethodCallExpressions
+      var currentCall = updateLambda.Body as MethodCallExpression;
+      while (currentCall != null && currentCall.Method.Name == "SetProperty")
+      {
+        var memberExpr = currentCall.Arguments[0] as LambdaExpression;
+        var valueExpr = currentCall.Arguments[1];
+
+        var propertyInfo = ((memberExpr.Body as MemberExpression)?.Member) as System.Reflection.PropertyInfo;
+        var value = Expression.Lambda(valueExpr).Compile().DynamicInvoke();
+
+        foreach (var item in affectedItems)
+        {
+          propertyInfo?.SetValue(item, value);
+        }
+
+        // Move to the next chained call (if any)
+        currentCall = currentCall.Object as MethodCallExpression;
+      }
     }
   }
 }

--- a/src/MockQueryable/MockQueryable.FakeItEasy/FakeItEasyExtensions.cs
+++ b/src/MockQueryable/MockQueryable.FakeItEasy/FakeItEasyExtensions.cs
@@ -8,61 +8,95 @@ using System.Threading.Tasks;
 
 namespace MockQueryable.FakeItEasy
 {
-    public static class FakeItEasyExtensions
+  public static class FakeItEasyExtensions
+  {
+    public static DbSet<TEntity> BuildMockDbSet<TEntity>(this IEnumerable<TEntity> data) where TEntity : class => data.BuildMock().BuildMockDbSet();
+
+    public static DbSet<TEntity> BuildMockDbSet<TEntity>(this IQueryable<TEntity> data) where TEntity : class
     {
-        public static DbSet<TEntity> BuildMockDbSet<TEntity>(this IEnumerable<TEntity> data) where TEntity : class => data.BuildMock().BuildMockDbSet();
+      var mock = A.Fake<DbSet<TEntity>>(d => d.Implements<IAsyncEnumerable<TEntity>>().Implements<IQueryable<TEntity>>());
+      var enumerable = new TestAsyncEnumerableEfCore<TEntity>(data);
 
-        public static DbSet<TEntity> BuildMockDbSet<TEntity>(this IQueryable<TEntity> data) where TEntity : class
-        {
-            var mock = A.Fake<DbSet<TEntity>>(d => d.Implements<IAsyncEnumerable<TEntity>>().Implements<IQueryable<TEntity>>());
-            var enumerable = new TestAsyncEnumerableEfCore<TEntity>(data);
-            mock.ConfigureQueryableCalls(enumerable, data);
-            mock.ConfigureAsyncEnumerableCalls(enumerable);
-            mock.ConfigureDbSetCalls(data);
-            if (mock is IAsyncEnumerable<TEntity> asyncEnumerable)
-            {
-                A.CallTo(() => asyncEnumerable.GetAsyncEnumerator(A<CancellationToken>.Ignored)).ReturnsLazily(() => enumerable.GetAsyncEnumerator());
-            }
-            return mock;
-        }
+      ConfigureAllCalls(mock, enumerable, data);
 
-
-        private static void ConfigureQueryableCalls<TEntity>(
-            this IQueryable<TEntity> mock,
-            IQueryProvider queryProvider,
-            IQueryable<TEntity> data) where TEntity : class
-        {
-            A.CallTo(() => mock.Provider).Returns(queryProvider);
-            A.CallTo(() => mock.Expression).Returns(data?.Expression);
-            A.CallTo(() => mock.ElementType).Returns(data?.ElementType);
-            A.CallTo(() => mock.GetEnumerator()).ReturnsLazily(() => data?.GetEnumerator());
-        }
-
-        private static void ConfigureAsyncEnumerableCalls<TEntity>(
-            this DbSet<TEntity> mock,
-            IAsyncEnumerable<TEntity> enumerable) where TEntity : class
-        {
-            A.CallTo(() => mock.GetAsyncEnumerator(A<CancellationToken>.Ignored))
-                .Returns(enumerable.GetAsyncEnumerator());
-           
-        }
-
-        private static void ConfigureDbSetCalls<TEntity>(this DbSet<TEntity> mock, IQueryable<TEntity> data)
-          where TEntity : class
-        {
-            A.CallTo(() => mock.AsQueryable()).Returns(data);
-            A.CallTo(() => mock.AsAsyncEnumerable()).ReturnsLazily(args => CreateAsyncMock(data));
-        }
-
-        private static async IAsyncEnumerable<TEntity> CreateAsyncMock<TEntity>(IEnumerable<TEntity> data)
-          where TEntity : class
-        {
-            foreach (var entity in data)
-            {
-                yield return entity;
-            }
-
-            await Task.CompletedTask;
-        }
+      return mock;
     }
+
+    public static DbSet<TEntity> BuildMockDbSetWithInterceptedExecuteDelete<TEntity>(
+      this ICollection<TEntity> data) where TEntity : class
+    {
+      var mock = A.Fake<DbSet<TEntity>>(d => d.Implements<IAsyncEnumerable<TEntity>>().Implements<IQueryable<TEntity>>());
+      var enumerable = new TestAsyncEnumerableEfCore<TEntity>(data, x => data.Remove(x));
+
+      ConfigureAllCalls(mock, enumerable, data.AsQueryable());
+
+      return mock;
+    }
+
+    public static DbSet<TEntity> BuildMockDbSetWithInterceptedExecuteDelete<TEntity>(
+        this DbSet<TEntity> data) where TEntity : class
+    {
+      var mock = A.Fake<DbSet<TEntity>>(d => d.Implements<IAsyncEnumerable<TEntity>>().Implements<IQueryable<TEntity>>());
+      var enumerable = new TestAsyncEnumerableEfCore<TEntity>(data, x => data.Remove(x));
+
+      ConfigureAllCalls(mock, enumerable, data);
+
+      return mock;
+    }
+
+    private static void ConfigureAllCalls<TEntity>(
+        this DbSet<TEntity> mock,
+        TestAsyncEnumerableEfCore<TEntity> enumerable,
+        IQueryable<TEntity> data) where TEntity : class
+    {
+      mock.ConfigureQueryableCalls(enumerable, data);
+      mock.ConfigureAsyncEnumerableCalls(enumerable);
+      mock.ConfigureDbSetCalls(data);
+      if (mock is IAsyncEnumerable<TEntity> asyncEnumerable)
+      {
+        A.CallTo(() => asyncEnumerable.GetAsyncEnumerator(A<CancellationToken>.Ignored)).ReturnsLazily(() => enumerable.GetAsyncEnumerator());
+      }
+    }
+
+    private static void ConfigureQueryableCalls<TEntity>(
+        this IQueryable<TEntity> mock,
+        IQueryProvider queryProvider,
+        IQueryable<TEntity> data) where TEntity : class
+    {
+      A.CallTo(() => mock.Provider).Returns(queryProvider);
+      A.CallTo(() => mock.Expression).Returns(data?.Expression);
+      A.CallTo(() => mock.ElementType).Returns(data?.ElementType);
+      A.CallTo(() => mock.GetEnumerator()).ReturnsLazily(() => data?.GetEnumerator());
+    }
+
+    private static void ConfigureAsyncEnumerableCalls<TEntity>(
+        this DbSet<TEntity> mock,
+        IAsyncEnumerable<TEntity> enumerable) where TEntity : class
+    {
+      A.CallTo(() => mock.GetAsyncEnumerator(A<CancellationToken>.Ignored))
+          .Returns(enumerable.GetAsyncEnumerator());
+
+    }
+
+    private static void ConfigureDbSetCalls<TEntity>(this DbSet<TEntity> mock, IQueryable<TEntity> data)
+      where TEntity : class
+    {
+      A.CallTo(() => mock.AsQueryable()).Returns(data.AsQueryable());
+      A.CallTo(() => mock.AsAsyncEnumerable()).ReturnsLazily(args => CreateAsyncMock(mock));
+    }
+
+    private static async IAsyncEnumerable<TEntity> CreateAsyncMock<TEntity>(
+      this IQueryable<TEntity> mock)
+      where TEntity : class
+    {
+      var data = await mock.ToListAsync();
+
+      foreach (var entity in data)
+      {
+        yield return entity;
+      }
+
+      await Task.CompletedTask;
+    }
+  }
 }

--- a/src/MockQueryable/MockQueryable.NSubstitute/NSubstituteExtensions.cs
+++ b/src/MockQueryable/MockQueryable.NSubstitute/NSubstituteExtensions.cs
@@ -17,18 +17,47 @@ namespace MockQueryable.NSubstitute
       var mock = Substitute.For<DbSet<TEntity>, IQueryable<TEntity>, IAsyncEnumerable<TEntity>>();
       var enumerable = new TestAsyncEnumerableEfCore<TEntity>(data);
 
+      ConfigureAllCalls(mock, enumerable, data);
+
+      return mock;
+    }
+
+    public static DbSet<TEntity> BuildMockDbSetWithInterceptedExecuteDelete<TEntity>(
+      this ICollection<TEntity> data) where TEntity : class
+    {
+      var mock = Substitute.For<DbSet<TEntity>, IQueryable<TEntity>, IAsyncEnumerable<TEntity>>();
+      var enumerable = new TestAsyncEnumerableEfCore<TEntity>(data, x => data.Remove(x));
+
+      ConfigureAllCalls(mock, enumerable, data.AsQueryable());
+
+      return mock;
+    }
+
+    public static DbSet<TEntity> BuildMockDbSetWithInterceptedExecuteDelete<TEntity>(
+        this DbSet<TEntity> data) where TEntity : class
+    {
+      var mock = Substitute.For<DbSet<TEntity>, IQueryable<TEntity>, IAsyncEnumerable<TEntity>>();
+      var enumerable = new TestAsyncEnumerableEfCore<TEntity>(data, x => data.Remove(x));
+
+      ConfigureAllCalls(mock, enumerable, data.AsQueryable());
+
+      return mock;
+    }
+
+    private static void ConfigureAllCalls<TEntity>(
+        this DbSet<TEntity> mock,
+        TestAsyncEnumerableEfCore<TEntity> enumerable,
+        IQueryable<TEntity> data) where TEntity : class
+    {
       mock.ConfigureAsyncEnumerableCalls(enumerable);
       mock.ConfigureQueryableCalls(enumerable, data);
       mock.ConfigureDbSetCalls(data);
 
       if (mock is IAsyncEnumerable<TEntity> asyncEnumerable)
       {
-          asyncEnumerable.GetAsyncEnumerator(Arg.Any<CancellationToken>()).Returns(args => enumerable.GetAsyncEnumerator());
+        asyncEnumerable.GetAsyncEnumerator(Arg.Any<CancellationToken>()).Returns(args => enumerable.GetAsyncEnumerator());
       }
-
-      return mock;
     }
-
 
     private static void ConfigureQueryableCalls<TEntity>(
       this IQueryable<TEntity> mock,

--- a/src/MockQueryable/MockQueryable.Sample/MyService.cs
+++ b/src/MockQueryable/MockQueryable.Sample/MyService.cs
@@ -92,7 +92,7 @@ namespace MockQueryable.Sample
 
         Task<int> DeleteUserAsync(Guid id);
 
-        Task<int> UpdateFirstNameByIdAsync(Guid id, string firstName);
+        Task<int> UpdateFirstAndLastNameByIdAsync(Guid id, string firstName);
     }
 
     public class UserReport

--- a/src/MockQueryable/MockQueryable.Sample/MyServiceFakeItEasyTests.cs
+++ b/src/MockQueryable/MockQueryable.Sample/MyServiceFakeItEasyTests.cs
@@ -1,13 +1,13 @@
-﻿using System;
+﻿using FakeItEasy;
+using Microsoft.EntityFrameworkCore;
+using MockQueryable.FakeItEasy;
+using NUnit.Framework;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using FakeItEasy;
-using Microsoft.EntityFrameworkCore;
-using MockQueryable.FakeItEasy;
-using NUnit.Framework;
 
 namespace MockQueryable.Sample
 {
@@ -115,8 +115,8 @@ namespace MockQueryable.Sample
     [TestCase("AnyFirstName", "ExistLastName", "01/20/2012", "User already exist")]
     public void DbSetCreatedFromCollectionCreateUserIfNotExist(string firstName, string lastName, DateTime dateOfBirth, string expectedError)
     {
-        //arrange
-        var users = new List<UserEntity>
+      //arrange
+      var users = new List<UserEntity>
         {
             new UserEntity {LastName = "ExistLastName", DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat)},
             new UserEntity {FirstName = "ExistFirstName"},
@@ -124,14 +124,14 @@ namespace MockQueryable.Sample
             new UserEntity {DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat)},
             new UserEntity {DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat)},
         };
-        var mock = users.BuildMockDbSet();
-        var userRepository = new TestDbSetRepository(mock);
-        var service = new MyService(userRepository);
-        //act
-        var ex = Assert.ThrowsAsync<ApplicationException>(() =>
-                                                              service.CreateUserIfNotExist(firstName, lastName, dateOfBirth));
-        //assert
-        Assert.AreEqual(expectedError, ex.Message);
+      var mock = users.BuildMockDbSet();
+      var userRepository = new TestDbSetRepository(mock);
+      var service = new MyService(userRepository);
+      //act
+      var ex = Assert.ThrowsAsync<ApplicationException>(() =>
+                                                            service.CreateUserIfNotExist(firstName, lastName, dateOfBirth));
+      //assert
+      Assert.AreEqual(expectedError, ex.Message);
 
     }
 
@@ -144,7 +144,7 @@ namespace MockQueryable.Sample
       A.CallTo(() => mock.AddAsync(A<UserEntity>._, A<CancellationToken>._))
         .ReturnsLazily(call =>
         {
-          userEntities.Add((UserEntity) call.Arguments[0]);
+          userEntities.Add((UserEntity)call.Arguments[0]);
           return default;
         });
       var userRepository = new TestDbSetRepository(mock);
@@ -161,24 +161,24 @@ namespace MockQueryable.Sample
     [TestCase("AnyFirstName", "ExistLastName", "01/20/2012")]
     public async Task DbSetCreatedFromCollectionCreateUser1(string firstName, string lastName, DateTime dateOfBirth)
     {
-        //arrange
-        var userEntities = new List<UserEntity>();
-        var mock = userEntities.BuildMockDbSet();
-        A.CallTo(() => mock.AddAsync(A<UserEntity>._, A<CancellationToken>._))
-         .ReturnsLazily(call =>
-         {
-             userEntities.Add((UserEntity)call.Arguments[0]);
-             return default;
-         });
-        var userRepository = new TestDbSetRepository(mock);
-        var service = new MyService(userRepository);
-        //act
-        await service.CreateUserIfNotExist(firstName, lastName, dateOfBirth);
-        // assert
-        var entity = mock.Single();
-        Assert.AreEqual(firstName, entity.FirstName);
-        Assert.AreEqual(lastName, entity.LastName);
-        Assert.AreEqual(dateOfBirth, entity.DateOfBirth);
+      //arrange
+      var userEntities = new List<UserEntity>();
+      var mock = userEntities.BuildMockDbSet();
+      A.CallTo(() => mock.AddAsync(A<UserEntity>._, A<CancellationToken>._))
+       .ReturnsLazily(call =>
+       {
+         userEntities.Add((UserEntity)call.Arguments[0]);
+         return default;
+       });
+      var userRepository = new TestDbSetRepository(mock);
+      var service = new MyService(userRepository);
+      //act
+      await service.CreateUserIfNotExist(firstName, lastName, dateOfBirth);
+      // assert
+      var entity = mock.Single();
+      Assert.AreEqual(firstName, entity.FirstName);
+      Assert.AreEqual(lastName, entity.LastName);
+      Assert.AreEqual(dateOfBirth, entity.DateOfBirth);
     }
 
     [TestCase("01/20/2012", "06/20/2018", 5)]
@@ -204,15 +204,15 @@ namespace MockQueryable.Sample
     [TestCase("01/20/2010", "02/20/2011", 0)]
     public async Task DbSetCreatedFromCollectionGetUserReports(DateTime from, DateTime to, int expectedCount)
     {
-        //arrange
-        var users = CreateUserList();
-        var mock = users.BuildMockDbSet();
-        var userRepository = new TestDbSetRepository(mock);
-        var service = new MyService(userRepository);
-        //act
-        var result = await service.GetUserReports(from, to);
-        //assert
-        Assert.AreEqual(expectedCount, result.Count);
+      //arrange
+      var users = CreateUserList();
+      var mock = users.BuildMockDbSet();
+      var userRepository = new TestDbSetRepository(mock);
+      var service = new MyService(userRepository);
+      //act
+      var result = await service.GetUserReports(from, to);
+      //assert
+      Assert.AreEqual(expectedCount, result.Count);
     }
 
     [Test]
@@ -234,31 +234,32 @@ namespace MockQueryable.Sample
     [Test]
     public async Task DbSetCreatedFromCollectionGetAllUserEntitiesAsync()
     {
-        // arrange
-        var users = CreateUserList();
+      // arrange
+      var users = CreateUserList();
 
-        var mockDbSet = users.BuildMockDbSet();
-        var userRepository = new TestDbSetRepository(mockDbSet);
+      var mockDbSet = users.BuildMockDbSet();
+      var userRepository = new TestDbSetRepository(mockDbSet);
 
-        // act
-        var result = await userRepository.GetAllAsync().ToListAsync();
+      // act
+      var result = await userRepository.GetAllAsync().ToListAsync();
 
-        // assert
-        Assert.AreEqual(users.Count, result.Count);
+      // assert
+      Assert.AreEqual(users.Count, result.Count);
     }
 
     [Test]
-    public async Task DbSetToListAsyncAsync_ShouldReturnAllEntities_WhenSourceIsChanged()
+    public async Task DbSetGetAllUserEntitiesAsync_ShouldReturnAllEntities_WhenSourceIsChanged()
     {
       // arrange
       var users = new List<UserEntity>();
 
       var mockDbSet = users.AsQueryable().BuildMockDbSet();
-      
+      var userRepository = new TestDbSetRepository(mockDbSet);
+
       // act
-      var result1 = await mockDbSet.ToListAsync();
+      var result1 = await userRepository.GetAllAsync().ToListAsync();
       users.AddRange(CreateUserList());
-      var result2 = await mockDbSet.ToListAsync();
+      var result2 = await userRepository.GetAllAsync().ToListAsync();
 
       // assert
       Assert.AreEqual(0, result1.Count);
@@ -268,97 +269,122 @@ namespace MockQueryable.Sample
     [Test]
     public async Task DbSetGetAllUserEntity()
     {
-        //arrange
-        var users = CreateUserList();
-        var mock = users.AsQueryable().BuildMockDbSet();
-        var userRepository = new TestDbSetRepository(mock);
-        //act
-        var result = await userRepository.GetAll();
-        //assert
-        Assert.AreEqual(users.Count, result.Count);
+      //arrange
+      var users = CreateUserList();
+      var mock = users.AsQueryable().BuildMockDbSet();
+      var userRepository = new TestDbSetRepository(mock);
+      //act
+      var result = await userRepository.GetAll();
+      //assert
+      Assert.AreEqual(users.Count, result.Count);
     }
 
     [Test]
     public async Task DbSetCreatedFromCollectionGetAllUserEntity()
     {
-        //arrange
-        var users = CreateUserList();
-        var mock = users.BuildMockDbSet();
-        var userRepository = new TestDbSetRepository(mock);
-        //act
-        var result = await userRepository.GetAll();
-        //assert
-        Assert.AreEqual(users.Count, result.Count);
+      //arrange
+      var users = CreateUserList();
+      var mock = users.BuildMockDbSet();
+      var userRepository = new TestDbSetRepository(mock);
+      //act
+      var result = await userRepository.GetAll();
+      //assert
+      Assert.AreEqual(users.Count, result.Count);
     }
 
+    [Test]
+    public async Task DbSetCreatedFromCollection_ExecuteDeleteAsync_NoInterceptionEntityNotRemoved()
+    {
+      // arrange
+      var userId = Guid.NewGuid();
+      var users = CreateUserList(userId);
+
+      var mockDbSet = users.BuildMockDbSet();
+      var userRepository = new TestDbSetRepository(mockDbSet);
+
+      // act
+      var count = await userRepository.DeleteUserAsync(userId);
+
+      // assert
+      Assert.AreEqual(1, count);
+      var updatedUsers = await userRepository.GetAllAsync().ToListAsync();
+      Assert.IsNotNull(updatedUsers.SingleOrDefault(x => x.Id == userId));
+    }
 
     [Test]
-    public async Task DbSetCreatedFromCollectionExecuteDeleteAsync()
+    public async Task DbSetCreatedFromCollection_ExecuteDeleteAsync_InterceptionEntityRemoved()
     {
-        // arrange
-        var userId = Guid.NewGuid();
-        var users = CreateUserList(userId);
+      // arrange
+      var userId = Guid.NewGuid();
+      var users = CreateUserList(userId);
 
-        var mockDbSet = users.BuildMockDbSet();
-        var userRepository = new TestDbSetRepository(mockDbSet);
+      var mockDbSet = users.BuildMockDbSetWithInterceptedExecuteDelete();
+      var userRepository = new TestDbSetRepository(mockDbSet);
 
-        // act
-        var count = await userRepository.DeleteUserAsync(userId);
+      // act
+      var count = await userRepository.DeleteUserAsync(userId);
 
-        // assert
-        Assert.AreEqual(1, count);
-
+      // assert
+      Assert.AreEqual(1, count);
+      var updatedUsers = await userRepository.GetAllAsync().ToListAsync();
+      Assert.IsNull(updatedUsers.SingleOrDefault(x => x.Id == userId));
     }
 
     [Test]
     public async Task DbSetCreatedFromCollectionExecuteDeleteAsync_ShouldReturnZero()
     {
-        // arrange
-        var userId = Guid.NewGuid();
-        var users = CreateUserList(userId);
+      // arrange
+      var userId = Guid.NewGuid();
+      var users = CreateUserList(userId);
 
-        var mockDbSet = users.BuildMockDbSet();
-        var userRepository = new TestDbSetRepository(mockDbSet);
+      var mockDbSet = users.BuildMockDbSet();
+      var userRepository = new TestDbSetRepository(mockDbSet);
 
-        //act
-        var count = await userRepository.DeleteUserAsync(Guid.NewGuid());
+      //act
+      var count = await userRepository.DeleteUserAsync(Guid.NewGuid());
 
-        // assert
-        Assert.AreEqual(0, count);
+      // assert
+      Assert.AreEqual(0, count);
+      var user = users.Single(x => x.Id == userId);
+      user.FirstName = "Unit Test";
+      user.LastName = "Unit Test";
     }
 
     [Test]
     public async Task DbSetCreatedFromCollectionExecuteUpdateAsync()
     {
-        // arrange
-        var userId = Guid.NewGuid();
-        var users = CreateUserList(userId);
+      // arrange
+      var userId = Guid.NewGuid();
+      var users = CreateUserList(userId);
 
-        var mockDbSet = users.BuildMockDbSet();
-        var userRepository = new TestDbSetRepository(mockDbSet);
-            
-        //act
-        var count = await userRepository.UpdateFirstNameByIdAsync(userId, "Unit Test");
+      var mockDbSet = users.BuildMockDbSet();
+      var userRepository = new TestDbSetRepository(mockDbSet);
 
-        //assert
-        Assert.AreEqual(1, count);
+      //act
+      var count = await userRepository.UpdateFirstAndLastNameByIdAsync(userId, "Unit Test");
+
+      //assert
+      Assert.AreEqual(1, count);
+      var user = users.Single(x => x.Id == userId);
+      user.FirstName = "Unit Test";
+      user.LastName = "Unit Test";
     }
 
     [Test]
     public async Task DbSetCreatedFromCollectionExecuteUpdateAsync_ShouldReturnZero()
     {
-        // arrange
-        var userId = Guid.NewGuid();
-        var users = CreateUserList(userId);
+      // arrange
+      var userId = Guid.NewGuid();
+      var users = CreateUserList(userId);
 
-        var mockDbSet = users.BuildMockDbSet();
-        var userRepository = new TestDbSetRepository(mockDbSet);
+      var mockDbSet = users.BuildMockDbSet();
+      var userRepository = new TestDbSetRepository(mockDbSet);
 
-        //act
-        var count = await userRepository.UpdateFirstNameByIdAsync(Guid.NewGuid(), "Unit Test");
+      //act
+      var count = await userRepository.UpdateFirstAndLastNameByIdAsync(Guid.NewGuid(), "Unit Test");
 
-        //assert
-        Assert.AreEqual(0, count);
+      //assert
+      Assert.AreEqual(0, count);
     }
 
     private static List<UserEntity> CreateUserList(Guid? userId = null) => new List<UserEntity>

--- a/src/MockQueryable/MockQueryable.Sample/MyServiceMoqTests.cs
+++ b/src/MockQueryable/MockQueryable.Sample/MyServiceMoqTests.cs
@@ -11,20 +11,20 @@ using System.Threading.Tasks;
 
 namespace MockQueryable.Sample
 {
-    [TestFixture]
-    public class MyServiceMoqTests
+  [TestFixture]
+  public class MyServiceMoqTests
+  {
+    private static readonly CultureInfo UsCultureInfo = new CultureInfo("en-US");
+
+    [TestCase("AnyFirstName", "AnyExistLastName", "01/20/2012", "Users with DateOfBirth more than limit")]
+    [TestCase("ExistFirstName", "AnyExistLastName", "02/20/2012", "User with FirstName already exist")]
+    [TestCase("AnyFirstName", "ExistLastName", "01/20/2012", "User already exist")]
+    public void CreateUserIfNotExist(string firstName, string lastName, DateTime dateOfBirth, string expectedError)
     {
-        private static readonly CultureInfo UsCultureInfo = new CultureInfo("en-US");
-
-        [TestCase("AnyFirstName", "AnyExistLastName", "01/20/2012", "Users with DateOfBirth more than limit")]
-        [TestCase("ExistFirstName", "AnyExistLastName", "02/20/2012", "User with FirstName already exist")]
-        [TestCase("AnyFirstName", "ExistLastName", "01/20/2012", "User already exist")]
-        public void CreateUserIfNotExist(string firstName, string lastName, DateTime dateOfBirth, string expectedError)
-        {
-            //arrange
-            var userRepository = new Mock<IUserRepository>();
-            var service = new MyService(userRepository.Object);
-            var users = new List<UserEntity>
+      //arrange
+      var userRepository = new Mock<IUserRepository>();
+      var service = new MyService(userRepository.Object);
+      var users = new List<UserEntity>
       {
         new UserEntity {LastName = "ExistLastName", DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat)},
         new UserEntity {FirstName = "ExistFirstName"},
@@ -32,64 +32,64 @@ namespace MockQueryable.Sample
         new UserEntity {DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat)},
         new UserEntity {DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat)}
       };
-            //expect
-            var mock = users.BuildMock();
-            userRepository.Setup(x => x.GetQueryable()).Returns(mock);
-            //act
-            var ex = Assert.ThrowsAsync<ApplicationException>(() =>
-              service.CreateUserIfNotExist(firstName, lastName, dateOfBirth));
-            //assert
-            Assert.AreEqual(expectedError, ex.Message);
-        }
+      //expect
+      var mock = users.BuildMock();
+      userRepository.Setup(x => x.GetQueryable()).Returns(mock);
+      //act
+      var ex = Assert.ThrowsAsync<ApplicationException>(() =>
+        service.CreateUserIfNotExist(firstName, lastName, dateOfBirth));
+      //assert
+      Assert.AreEqual(expectedError, ex.Message);
+    }
 
-        [TestCase("01/20/2012", "06/20/2018", 5)]
-        [TestCase("01/20/2012", "06/20/2012", 4)]
-        [TestCase("01/20/2012", "02/20/2012", 3)]
-        [TestCase("01/20/2010", "02/20/2011", 0)]
-        public async Task GetUserReports(DateTime from, DateTime to, int expectedCount)
-        {
-            //arrange
-            var userRepository = new Mock<IUserRepository>();
-            var service = new MyService(userRepository.Object);
-            var users = CreateUserList();
-            //expect
-            var mock = users.BuildMock();
-            userRepository.Setup(x => x.GetQueryable()).Returns(mock);
-            //act
-            var result = await service.GetUserReports(from, to);
-            //assert
-            Assert.AreEqual(expectedCount, result.Count);
-        }
-
-
-
-        [TestCase("01/20/2012", "06/20/2018", 5)]
-        [TestCase("01/20/2012", "06/20/2012", 4)]
-        [TestCase("01/20/2012", "02/20/2012", 3)]
-        [TestCase("01/20/2010", "02/20/2011", 0)]
-        public async Task GetUserReports_AutoMap(DateTime from, DateTime to, int expectedCount)
-        {
-            //arrange
-            var userRepository = new Mock<IUserRepository>();
-            var service = new MyService(userRepository.Object);
-            var users = CreateUserList();
-            //expect
-            var mock = users.BuildMock();
-            userRepository.Setup(x => x.GetQueryable()).Returns(mock);
-            //act
-            var result = await service.GetUserReportsAutoMap(from, to);
-            //assert
-            Assert.AreEqual(expectedCount, result.Count);
-        }
+    [TestCase("01/20/2012", "06/20/2018", 5)]
+    [TestCase("01/20/2012", "06/20/2012", 4)]
+    [TestCase("01/20/2012", "02/20/2012", 3)]
+    [TestCase("01/20/2010", "02/20/2011", 0)]
+    public async Task GetUserReports(DateTime from, DateTime to, int expectedCount)
+    {
+      //arrange
+      var userRepository = new Mock<IUserRepository>();
+      var service = new MyService(userRepository.Object);
+      var users = CreateUserList();
+      //expect
+      var mock = users.BuildMock();
+      userRepository.Setup(x => x.GetQueryable()).Returns(mock);
+      //act
+      var result = await service.GetUserReports(from, to);
+      //assert
+      Assert.AreEqual(expectedCount, result.Count);
+    }
 
 
-        [TestCase("AnyFirstName", "AnyExistLastName", "01/20/2012", "Users with DateOfBirth more than limit")]
-        [TestCase("ExistFirstName", "AnyExistLastName", "02/20/2012", "User with FirstName already exist")]
-        [TestCase("AnyFirstName", "ExistLastName", "01/20/2012", "User already exist")]
-        public void DbSetCreateUserIfNotExist(string firstName, string lastName, DateTime dateOfBirth, string expectedError)
-        {
-            //arrange
-            var users = new List<UserEntity>
+
+    [TestCase("01/20/2012", "06/20/2018", 5)]
+    [TestCase("01/20/2012", "06/20/2012", 4)]
+    [TestCase("01/20/2012", "02/20/2012", 3)]
+    [TestCase("01/20/2010", "02/20/2011", 0)]
+    public async Task GetUserReports_AutoMap(DateTime from, DateTime to, int expectedCount)
+    {
+      //arrange
+      var userRepository = new Mock<IUserRepository>();
+      var service = new MyService(userRepository.Object);
+      var users = CreateUserList();
+      //expect
+      var mock = users.BuildMock();
+      userRepository.Setup(x => x.GetQueryable()).Returns(mock);
+      //act
+      var result = await service.GetUserReportsAutoMap(from, to);
+      //assert
+      Assert.AreEqual(expectedCount, result.Count);
+    }
+
+
+    [TestCase("AnyFirstName", "AnyExistLastName", "01/20/2012", "Users with DateOfBirth more than limit")]
+    [TestCase("ExistFirstName", "AnyExistLastName", "02/20/2012", "User with FirstName already exist")]
+    [TestCase("AnyFirstName", "ExistLastName", "01/20/2012", "User already exist")]
+    public void DbSetCreateUserIfNotExist(string firstName, string lastName, DateTime dateOfBirth, string expectedError)
+    {
+      //arrange
+      var users = new List<UserEntity>
       {
         new UserEntity {LastName = "ExistLastName", DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat)},
         new UserEntity {FirstName = "ExistFirstName"},
@@ -97,23 +97,23 @@ namespace MockQueryable.Sample
         new UserEntity {DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat)},
         new UserEntity {DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat)}
       };
-            var mock = users.AsQueryable().BuildMockDbSet();
-            var userRepository = new TestDbSetRepository(mock.Object);
-            var service = new MyService(userRepository);
-            //act
-            var ex = Assert.ThrowsAsync<ApplicationException>(() =>
-              service.CreateUserIfNotExist(firstName, lastName, dateOfBirth));
-            //assert
-            Assert.AreEqual(expectedError, ex.Message);
-        }
+      var mock = users.AsQueryable().BuildMockDbSet();
+      var userRepository = new TestDbSetRepository(mock.Object);
+      var service = new MyService(userRepository);
+      //act
+      var ex = Assert.ThrowsAsync<ApplicationException>(() =>
+        service.CreateUserIfNotExist(firstName, lastName, dateOfBirth));
+      //assert
+      Assert.AreEqual(expectedError, ex.Message);
+    }
 
-        [TestCase("AnyFirstName", "AnyExistLastName", "01/20/2012", "Users with DateOfBirth more than limit")]
-        [TestCase("ExistFirstName", "AnyExistLastName", "02/20/2012", "User with FirstName already exist")]
-        [TestCase("AnyFirstName", "ExistLastName", "01/20/2012", "User already exist")]
-        public void DbSetCreatedFromCollectionCreateUserIfNotExist(string firstName, string lastName, DateTime dateOfBirth, string expectedError)
-        {
-            //arrange
-            var users = new List<UserEntity>
+    [TestCase("AnyFirstName", "AnyExistLastName", "01/20/2012", "Users with DateOfBirth more than limit")]
+    [TestCase("ExistFirstName", "AnyExistLastName", "02/20/2012", "User with FirstName already exist")]
+    [TestCase("AnyFirstName", "ExistLastName", "01/20/2012", "User already exist")]
+    public void DbSetCreatedFromCollectionCreateUserIfNotExist(string firstName, string lastName, DateTime dateOfBirth, string expectedError)
+    {
+      //arrange
+      var users = new List<UserEntity>
         {
             new UserEntity {LastName = "ExistLastName", DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat)},
             new UserEntity {FirstName = "ExistFirstName"},
@@ -121,122 +121,122 @@ namespace MockQueryable.Sample
             new UserEntity {DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat)},
             new UserEntity {DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat)}
         };
-            var mock = users.BuildMockDbSet();
-            var userRepository = new TestDbSetRepository(mock.Object);
-            var service = new MyService(userRepository);
-            //act
-            var ex = Assert.ThrowsAsync<ApplicationException>(() =>
-                                                                  service.CreateUserIfNotExist(firstName, lastName, dateOfBirth));
-            //assert
-            Assert.AreEqual(expectedError, ex.Message);
-        }
+      var mock = users.BuildMockDbSet();
+      var userRepository = new TestDbSetRepository(mock.Object);
+      var service = new MyService(userRepository);
+      //act
+      var ex = Assert.ThrowsAsync<ApplicationException>(() =>
+                                                            service.CreateUserIfNotExist(firstName, lastName, dateOfBirth));
+      //assert
+      Assert.AreEqual(expectedError, ex.Message);
+    }
 
-        [TestCase("AnyFirstName", "ExistLastName", "01/20/2012")]
-        public async Task DbSetCreateUser(string firstName, string lastName, DateTime dateOfBirth)
-        {
-            //arrange
-            var userEntities = new List<UserEntity>();
-            var mock = userEntities.AsQueryable().BuildMockDbSet();
+    [TestCase("AnyFirstName", "ExistLastName", "01/20/2012")]
+    public async Task DbSetCreateUser(string firstName, string lastName, DateTime dateOfBirth)
+    {
+      //arrange
+      var userEntities = new List<UserEntity>();
+      var mock = userEntities.AsQueryable().BuildMockDbSet();
 
-            mock.Setup(set => set.AddAsync(It.IsAny<UserEntity>(), It.IsAny<CancellationToken>()))
-                .Callback((UserEntity entity, CancellationToken _) => userEntities.Add(entity));
-            var userRepository = new TestDbSetRepository(mock.Object);
-            var service = new MyService(userRepository);
-            //act
-            await service.CreateUserIfNotExist(firstName, lastName, dateOfBirth);
-            // assert
-            var entity = mock.Object.Single();
-            Assert.AreEqual(firstName, entity.FirstName);
-            Assert.AreEqual(lastName, entity.LastName);
-            Assert.AreEqual(dateOfBirth, entity.DateOfBirth);
-        }
+      mock.Setup(set => set.AddAsync(It.IsAny<UserEntity>(), It.IsAny<CancellationToken>()))
+          .Callback((UserEntity entity, CancellationToken _) => userEntities.Add(entity));
+      var userRepository = new TestDbSetRepository(mock.Object);
+      var service = new MyService(userRepository);
+      //act
+      await service.CreateUserIfNotExist(firstName, lastName, dateOfBirth);
+      // assert
+      var entity = mock.Object.Single();
+      Assert.AreEqual(firstName, entity.FirstName);
+      Assert.AreEqual(lastName, entity.LastName);
+      Assert.AreEqual(dateOfBirth, entity.DateOfBirth);
+    }
 
-        [TestCase("AnyFirstName", "ExistLastName", "01/20/2012")]
-        public async Task DbSetCreatedFromCollectionCreateUser(string firstName, string lastName, DateTime dateOfBirth)
-        {
-            //arrange
-            var userEntities = new List<UserEntity>();
-            var mock = userEntities.BuildMockDbSet();
+    [TestCase("AnyFirstName", "ExistLastName", "01/20/2012")]
+    public async Task DbSetCreatedFromCollectionCreateUser(string firstName, string lastName, DateTime dateOfBirth)
+    {
+      //arrange
+      var userEntities = new List<UserEntity>();
+      var mock = userEntities.BuildMockDbSet();
 
-            mock.Setup(set => set.AddAsync(It.IsAny<UserEntity>(), It.IsAny<CancellationToken>()))
-                .Callback((UserEntity entity, CancellationToken _) => userEntities.Add(entity));
-            var userRepository = new TestDbSetRepository(mock.Object);
-            var service = new MyService(userRepository);
-            //act
-            await service.CreateUserIfNotExist(firstName, lastName, dateOfBirth);
-            // assert
-            var entity = mock.Object.Single();
-            Assert.AreEqual(firstName, entity.FirstName);
-            Assert.AreEqual(lastName, entity.LastName);
-            Assert.AreEqual(dateOfBirth, entity.DateOfBirth);
-        }
+      mock.Setup(set => set.AddAsync(It.IsAny<UserEntity>(), It.IsAny<CancellationToken>()))
+          .Callback((UserEntity entity, CancellationToken _) => userEntities.Add(entity));
+      var userRepository = new TestDbSetRepository(mock.Object);
+      var service = new MyService(userRepository);
+      //act
+      await service.CreateUserIfNotExist(firstName, lastName, dateOfBirth);
+      // assert
+      var entity = mock.Object.Single();
+      Assert.AreEqual(firstName, entity.FirstName);
+      Assert.AreEqual(lastName, entity.LastName);
+      Assert.AreEqual(dateOfBirth, entity.DateOfBirth);
+    }
 
-        [TestCase("01/20/2012", "06/20/2018", 5)]
-        [TestCase("01/20/2012", "06/20/2012", 4)]
-        [TestCase("01/20/2012", "02/20/2012", 3)]
-        [TestCase("01/20/2010", "02/20/2011", 0)]
-        public async Task DbSetGetUserReports(DateTime from, DateTime to, int expectedCount)
-        {
-            //arrange
-            var users = CreateUserList();
-            var mock = users.AsQueryable().BuildMockDbSet();
-            var userRepository = new TestDbSetRepository(mock.Object);
-            var service = new MyService(userRepository);
-            //act
-            var result = await service.GetUserReports(from, to);
-            //assert
-            Assert.AreEqual(expectedCount, result.Count);
-        }
+    [TestCase("01/20/2012", "06/20/2018", 5)]
+    [TestCase("01/20/2012", "06/20/2012", 4)]
+    [TestCase("01/20/2012", "02/20/2012", 3)]
+    [TestCase("01/20/2010", "02/20/2011", 0)]
+    public async Task DbSetGetUserReports(DateTime from, DateTime to, int expectedCount)
+    {
+      //arrange
+      var users = CreateUserList();
+      var mock = users.AsQueryable().BuildMockDbSet();
+      var userRepository = new TestDbSetRepository(mock.Object);
+      var service = new MyService(userRepository);
+      //act
+      var result = await service.GetUserReports(from, to);
+      //assert
+      Assert.AreEqual(expectedCount, result.Count);
+    }
 
-        [TestCase("01/20/2012", "06/20/2018", 5)]
-        [TestCase("01/20/2012", "06/20/2012", 4)]
-        [TestCase("01/20/2012", "02/20/2012", 3)]
-        [TestCase("01/20/2010", "02/20/2011", 0)]
-        public async Task DbSetCreatedFromCollectionGetUserReports(DateTime from, DateTime to, int expectedCount)
-        {
-            //arrange
-            var users = CreateUserList();
-            var mock = users.BuildMockDbSet();
-            var userRepository = new TestDbSetRepository(mock.Object);
-            var service = new MyService(userRepository);
-            //act
-            var result = await service.GetUserReports(from, to);
-            //assert
-            Assert.AreEqual(expectedCount, result.Count);
-        }
+    [TestCase("01/20/2012", "06/20/2018", 5)]
+    [TestCase("01/20/2012", "06/20/2012", 4)]
+    [TestCase("01/20/2012", "02/20/2012", 3)]
+    [TestCase("01/20/2010", "02/20/2011", 0)]
+    public async Task DbSetCreatedFromCollectionGetUserReports(DateTime from, DateTime to, int expectedCount)
+    {
+      //arrange
+      var users = CreateUserList();
+      var mock = users.BuildMockDbSet();
+      var userRepository = new TestDbSetRepository(mock.Object);
+      var service = new MyService(userRepository);
+      //act
+      var result = await service.GetUserReports(from, to);
+      //assert
+      Assert.AreEqual(expectedCount, result.Count);
+    }
 
-        [Test]
-        public async Task DbSetGetAllUserEntity()
-        {
-            //arrange
-            var users = CreateUserList();
-            var mock = users.AsQueryable().BuildMockDbSet();
-            var userRepository = new TestDbSetRepository(mock.Object);
-            //act
-            var result = await userRepository.GetAll();
-            //assert
-            Assert.AreEqual(users.Count, result.Count);
-        }
+    [Test]
+    public async Task DbSetGetAllUserEntity()
+    {
+      //arrange
+      var users = CreateUserList();
+      var mock = users.AsQueryable().BuildMockDbSet();
+      var userRepository = new TestDbSetRepository(mock.Object);
+      //act
+      var result = await userRepository.GetAll();
+      //assert
+      Assert.AreEqual(users.Count, result.Count);
+    }
 
-        [Test]
-        public async Task DbSetCreatedFromCollectionGetAllUserEntity()
-        {
-            //arrange
-            var users = CreateUserList();
-            var mock = users.BuildMockDbSet();
-            var userRepository = new TestDbSetRepository(mock.Object);
-            //act
-            var result = await userRepository.GetAll();
-            //assert
-            Assert.AreEqual(users.Count, result.Count);
-        }
+    [Test]
+    public async Task DbSetCreatedFromCollectionGetAllUserEntity()
+    {
+      //arrange
+      var users = CreateUserList();
+      var mock = users.BuildMockDbSet();
+      var userRepository = new TestDbSetRepository(mock.Object);
+      //act
+      var result = await userRepository.GetAll();
+      //assert
+      Assert.AreEqual(users.Count, result.Count);
+    }
 
-        [Test]
-        public async Task DbSetFindAsyncUserEntity()
-        {
-            //arrange
-            var userId = Guid.NewGuid();
-            var users = new List<UserEntity>
+    [Test]
+    public async Task DbSetFindAsyncUserEntity()
+    {
+      //arrange
+      var userId = Guid.NewGuid();
+      var users = new List<UserEntity>
       {
         new UserEntity
         {
@@ -270,29 +270,29 @@ namespace MockQueryable.Sample
         }
       };
 
-            var mock = users.AsQueryable().BuildMockDbSet();
-            mock.Setup(x => x.FindAsync(It.IsAny<object[]>())).ReturnsAsync((object[] ids) =>
-            {
-                var id = (Guid) ids.First();
-                return users.FirstOrDefault(x => x.Id == id);
-            });
-            var userRepository = new TestDbSetRepository(mock.Object);
+      var mock = users.AsQueryable().BuildMockDbSet();
+      mock.Setup(x => x.FindAsync(It.IsAny<object[]>())).ReturnsAsync((object[] ids) =>
+      {
+        var id = (Guid)ids.First();
+        return users.FirstOrDefault(x => x.Id == id);
+      });
+      var userRepository = new TestDbSetRepository(mock.Object);
 
-            //act
-            var result = await ((DbSet<UserEntity>)userRepository.GetQueryable()).FindAsync(userId);
+      //act
+      var result = await ((DbSet<UserEntity>)userRepository.GetQueryable()).FindAsync(userId);
 
-            //assert
-            Assert.IsNotNull(result);
-            Assert.AreEqual("FirstName3", result.FirstName);
-        }
+      //assert
+      Assert.IsNotNull(result);
+      Assert.AreEqual("FirstName3", result.FirstName);
+    }
 
 
-        [Test]
-        public async Task DbSetCreatedFromCollectionFindAsyncUserEntity()
-        {
-            //arrange
-            var userId = Guid.NewGuid();
-            var users = new List<UserEntity>
+    [Test]
+    public async Task DbSetCreatedFromCollectionFindAsyncUserEntity()
+    {
+      //arrange
+      var userId = Guid.NewGuid();
+      var users = new List<UserEntity>
         {
             new UserEntity
             {
@@ -326,143 +326,170 @@ namespace MockQueryable.Sample
             }
         };
 
-            var mock = users.BuildMockDbSet();
-            mock.Setup(x => x.FindAsync(It.IsAny<object[]>())).ReturnsAsync((object[] ids) =>
-            {
-                var id = (Guid)ids.First();
-                return users.FirstOrDefault(x => x.Id == id);
-            });
-            var userRepository = new TestDbSetRepository(mock.Object);
+      var mock = users.BuildMockDbSet();
+      mock.Setup(x => x.FindAsync(It.IsAny<object[]>())).ReturnsAsync((object[] ids) =>
+      {
+        var id = (Guid)ids.First();
+        return users.FirstOrDefault(x => x.Id == id);
+      });
+      var userRepository = new TestDbSetRepository(mock.Object);
 
-            //act
-            var result = await ((DbSet<UserEntity>)userRepository.GetQueryable()).FindAsync(userId);
+      //act
+      var result = await ((DbSet<UserEntity>)userRepository.GetQueryable()).FindAsync(userId);
 
-            //assert
-            Assert.IsNotNull(result);
-            Assert.AreEqual("FirstName3", result.FirstName);
-        }
+      //assert
+      Assert.IsNotNull(result);
+      Assert.AreEqual("FirstName3", result.FirstName);
+    }
 
-        [Test]
-        public async Task DbSetGetAllUserEntitiesAsync()
-        {
-            // arrange
-            var users = CreateUserList();
+    [Test]
+    public async Task DbSetGetAllUserEntitiesAsync()
+    {
+      // arrange
+      var users = CreateUserList();
 
-            var mockDbSet = users.AsQueryable().BuildMockDbSet();
-            var userRepository = new TestDbSetRepository(mockDbSet.Object);
+      var mockDbSet = users.AsQueryable().BuildMockDbSet();
+      var userRepository = new TestDbSetRepository(mockDbSet.Object);
 
-            // act
-            var result = await userRepository.GetAllAsync().ToListAsync();
+      // act
+      var result = await userRepository.GetAllAsync().ToListAsync();
 
-            // assert
-            Assert.AreEqual(users.Count, result.Count);
-        }
+      // assert
+      Assert.AreEqual(users.Count, result.Count);
+    }
 
 
-        [Test]
-        public async Task DbSetToListAsyncAsync_ShouldReturnAllEntities_WhenSourceIsChanged()
-        {
-            // arrange
-            var users = new List<UserEntity>();
+    [Test]
+    public async Task DbSetGetAllUserEntitiesAsync_ShouldReturnAllEntities_WhenSourceIsChanged()
+    {
+      // arrange
+      var users = new List<UserEntity>();
 
-            var mockDbSet = users.AsQueryable().BuildMockDbSet();
+      var mockDbSet = users.AsQueryable().BuildMockDbSet();
+      var userRepository = new TestDbSetRepository(mockDbSet.Object);
 
-            // act
-            var result1 = await mockDbSet.Object.ToListAsync();
-            users.AddRange(CreateUserList());
-            var result2 = await mockDbSet.Object.ToListAsync();
+      // act
+      var result1 = await userRepository.GetAllAsync().ToListAsync();
+      users.AddRange(CreateUserList());
+      var result2 = await userRepository.GetAllAsync().ToListAsync();
 
-            // assert
-            Assert.AreEqual(0, result1.Count);
-            Assert.AreEqual(users.Count, result2.Count);
-        }
+      // assert
+      Assert.AreEqual(0, result1.Count);
+      Assert.AreEqual(users.Count, result2.Count);
+    }
 
-        [Test]
-        public async Task DbSetCreatedFromCollectionGetAllUserEntitiesAsync()
-        {
-            // arrange
-            var users = CreateUserList();
+    [Test]
+    public async Task DbSetCreatedFromCollectionGetAllUserEntitiesAsync()
+    {
+      // arrange
+      var users = CreateUserList();
 
-            var mockDbSet = users.BuildMockDbSet();
-            var userRepository = new TestDbSetRepository(mockDbSet.Object);
+      var mockDbSet = users.BuildMockDbSet();
+      var userRepository = new TestDbSetRepository(mockDbSet.Object);
 
-            // act
-            var result = await userRepository.GetAllAsync().ToListAsync();
+      // act
+      var result = await userRepository.GetAllAsync().ToListAsync();
 
-            // assert
-            Assert.AreEqual(users.Count, result.Count);
-        }
+      // assert
+      Assert.AreEqual(users.Count, result.Count);
+    }
 
-        [Test]
-        public async Task DbSetCreatedFromCollectionExecuteDeleteAsync()
-        {
-            // arrange
-            var userId = Guid.NewGuid();
-            var users = CreateUserList(userId);
+    [Test]
+    public async Task DbSetCreatedFromCollection_ExecuteDeleteAsync_NoInterceptionEntityNotRemoved()
+    {
+      // arrange
+      var userId = Guid.NewGuid();
+      var users = CreateUserList(userId);
 
-            var mockDbSet = users.BuildMockDbSet();
-            var userRepository = new TestDbSetRepository(mockDbSet.Object);
+      var mockDbSet = users.BuildMockDbSet();
+      var userRepository = new TestDbSetRepository(mockDbSet.Object);
 
-            // act
-            var count = await userRepository.DeleteUserAsync(userId);
+      // act
+      var count = await userRepository.DeleteUserAsync(userId);
 
-            // assert
-            Assert.AreEqual(1, count);
+      // assert
+      Assert.AreEqual(1, count);
+      var updatedUsers = await userRepository.GetAllAsync().ToListAsync();
+      Assert.IsNotNull(updatedUsers.SingleOrDefault(x => x.Id == userId));
+    }
 
-        }
+    [Test]
+    public async Task DbSetCreatedFromCollection_ExecuteDeleteAsync_InterceptionEntityRemoved()
+    {
+      // arrange
+      var userId = Guid.NewGuid();
+      var users = CreateUserList(userId);
 
-        [Test]
-        public async Task DbSetCreatedFromCollectionExecuteDeleteAsync_ShouldReturnZero()
-        {
-            // arrange
-            var userId = Guid.NewGuid();
-            var users = CreateUserList(userId);
+      var mockDbSet = users.BuildMockDbSetWithInterceptedExecuteDelete();
+      var userRepository = new TestDbSetRepository(mockDbSet.Object);
 
-            var mockDbSet = users.BuildMockDbSet();
-            var userRepository = new TestDbSetRepository(mockDbSet.Object);
+      // act
+      var count = await userRepository.DeleteUserAsync(userId);
 
-            //act
-            var count = await userRepository.DeleteUserAsync(Guid.NewGuid());
+      // assert
+      Assert.AreEqual(1, count);
+      var updatedUsers = await userRepository.GetAllAsync().ToListAsync();
+      Assert.IsNull(updatedUsers.SingleOrDefault(x => x.Id == userId));
+    }
 
-            // assert
-            Assert.AreEqual(0, count);
-        }
+    [Test]
+    public async Task DbSetCreatedFromCollectionExecuteDeleteAsync_ShouldReturnZero()
+    {
+      // arrange
+      var userId = Guid.NewGuid();
+      var users = CreateUserList(userId);
 
-        [Test]
-        public async Task DbSetCreatedFromCollectionExecuteUpdateAsync()
-        {
-            // arrange
-            var userId = Guid.NewGuid();
-            var users = CreateUserList(userId);
+      var mockDbSet = users.BuildMockDbSet();
+      var userRepository = new TestDbSetRepository(mockDbSet.Object);
 
-            var mockDbSet = users.BuildMockDbSet();
-            var userRepository = new TestDbSetRepository(mockDbSet.Object);
-            
-            //act
-            var count = await userRepository.UpdateFirstNameByIdAsync(userId, "Unit Test");
+      //act
+      var count = await userRepository.DeleteUserAsync(Guid.NewGuid());
 
-            //assert
-            Assert.AreEqual(1, count);
-        }
+      // assert
+      Assert.AreEqual(0, count);
+    }
 
-        [Test]
-        public async Task DbSetCreatedFromCollectionExecuteUpdateAsync_ShouldReturnZero()
-        {
-            // arrange
-            var userId = Guid.NewGuid();
-            var users = CreateUserList(userId);
+    [Test]
+    public async Task DbSetCreatedFromCollectionExecuteUpdateAsync()
+    {
+      // arrange
+      var userId = Guid.NewGuid();
+      var users = CreateUserList(userId);
 
-            var mockDbSet = users.BuildMockDbSet();
-            var userRepository = new TestDbSetRepository(mockDbSet.Object);
+      var mockDbSet = users.BuildMockDbSet();
+      var userRepository = new TestDbSetRepository(mockDbSet.Object);
 
-            //act
-            var count = await userRepository.UpdateFirstNameByIdAsync(Guid.NewGuid(), "Unit Test");
+      //act
+      var count = await userRepository.UpdateFirstAndLastNameByIdAsync(userId, "Unit Test");
 
-            //assert
-            Assert.AreEqual(0, count);
-        }
+      //assert
+      Assert.AreEqual(1, count);
+      var user = users.Single(x => x.Id == userId);
+      user.FirstName = "Unit Test";
+      user.LastName = "Unit Test";
+    }
 
-        private static List<UserEntity> CreateUserList(Guid? userId = null) => new List<UserEntity>
+    [Test]
+    public async Task DbSetCreatedFromCollectionExecuteUpdateAsync_ShouldReturnZero()
+    {
+      // arrange
+      var userId = Guid.NewGuid();
+      var users = CreateUserList(userId);
+
+      var mockDbSet = users.BuildMockDbSet();
+      var userRepository = new TestDbSetRepository(mockDbSet.Object);
+
+      //act
+      var count = await userRepository.UpdateFirstAndLastNameByIdAsync(Guid.NewGuid(), "Unit Test");
+
+      //assert
+      Assert.AreEqual(0, count);
+      var user = users.Single(x => x.Id == userId);
+      user.FirstName = "Unit Test";
+      user.LastName = "Unit Test";
+    }
+
+    private static List<UserEntity> CreateUserList(Guid? userId = null) => new List<UserEntity>
         {
             new UserEntity { Id = userId ?? Guid.NewGuid(), FirstName = "FirstName1", LastName = "LastName", DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat) },
             new UserEntity { Id = Guid.NewGuid(), FirstName = "FirstName2", LastName = "LastName", DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat) },
@@ -470,5 +497,5 @@ namespace MockQueryable.Sample
             new UserEntity { Id = Guid.NewGuid(), FirstName = "FirstName3", LastName = "LastName", DateOfBirth = DateTime.Parse("03/20/2012", UsCultureInfo.DateTimeFormat) },
             new UserEntity { Id = Guid.NewGuid(), FirstName = "FirstName5", LastName = "LastName", DateOfBirth = DateTime.Parse("01/20/2018", UsCultureInfo.DateTimeFormat) },
         };
-    }
+  }
 }

--- a/src/MockQueryable/MockQueryable.Sample/MyServiceNSubstituteTests.cs
+++ b/src/MockQueryable/MockQueryable.Sample/MyServiceNSubstituteTests.cs
@@ -9,103 +9,103 @@ using System.Threading.Tasks;
 
 namespace MockQueryable.Sample
 {
-    [TestFixture]
-    public class MyServiceNSubstituteTests
+  [TestFixture]
+  public class MyServiceNSubstituteTests
+  {
+    private static readonly CultureInfo UsCultureInfo = new CultureInfo("en-US");
+
+
+    [TestCase("AnyFirstName", "AnyExistLastName", "01/20/2012", "Users with DateOfBirth more than limit")]
+    [TestCase("ExistFirstName", "AnyExistLastName", "02/20/2012", "User with FirstName already exist")]
+    [TestCase("AnyFirstName", "ExistLastName", "01/20/2012", "User already exist")]
+    public void CreateUserIfNotExist(string firstName, string lastName, DateTime dateOfBirth, string expectedError)
     {
-        private static readonly CultureInfo UsCultureInfo = new CultureInfo("en-US");
+      //arrange
+      var userRepository = Substitute.For<IUserRepository>();
+      var service = new MyService(userRepository);
+      var users = new List<UserEntity>
+      {
+        new UserEntity{LastName = "ExistLastName", DateOfBirth = DateTime.Parse("01/20/2012",UsCultureInfo.DateTimeFormat)},
+        new UserEntity{FirstName = "ExistFirstName"},
+        new UserEntity{DateOfBirth = DateTime.Parse("01/20/2012",UsCultureInfo.DateTimeFormat)},
+        new UserEntity{DateOfBirth = DateTime.Parse("01/20/2012",UsCultureInfo.DateTimeFormat)},
+        new UserEntity{DateOfBirth = DateTime.Parse("01/20/2012",UsCultureInfo.DateTimeFormat)},
+      };
+      //expect
+      var mock = users.BuildMock();
+      userRepository.GetQueryable().Returns(mock);
+      //act
+      var ex = Assert.ThrowsAsync<ApplicationException>(() => service.CreateUserIfNotExist(firstName, lastName, dateOfBirth));
+      //assert
+      Assert.AreEqual(expectedError, ex.Message);
 
+    }
 
-        [TestCase("AnyFirstName", "AnyExistLastName", "01/20/2012", "Users with DateOfBirth more than limit")]
-		[TestCase("ExistFirstName", "AnyExistLastName", "02/20/2012", "User with FirstName already exist")]
-		[TestCase("AnyFirstName", "ExistLastName", "01/20/2012", "User already exist")]
-		public void CreateUserIfNotExist(string firstName, string lastName, DateTime dateOfBirth, string expectedError)
-		{
-            //arrange
-		    var userRepository = Substitute.For<IUserRepository>();
-		    var service = new MyService(userRepository);
-            var users = new List<UserEntity>
-			{
-				new UserEntity{LastName = "ExistLastName", DateOfBirth = DateTime.Parse("01/20/2012",UsCultureInfo.DateTimeFormat)},
-				new UserEntity{FirstName = "ExistFirstName"},
-				new UserEntity{DateOfBirth = DateTime.Parse("01/20/2012",UsCultureInfo.DateTimeFormat)},
-				new UserEntity{DateOfBirth = DateTime.Parse("01/20/2012",UsCultureInfo.DateTimeFormat)},
-				new UserEntity{DateOfBirth = DateTime.Parse("01/20/2012",UsCultureInfo.DateTimeFormat)},
-			};
-			//expect
-			var mock = users.BuildMock();
-			userRepository.GetQueryable().Returns(mock);
-			//act
-			var ex= Assert.ThrowsAsync<ApplicationException>(() => service.CreateUserIfNotExist(firstName, lastName, dateOfBirth));
-			//assert
-			Assert.AreEqual(expectedError, ex.Message);
+    [TestCase("01/20/2012", "06/20/2018", 5)]
+    [TestCase("01/20/2012", "06/20/2012", 4)]
+    [TestCase("01/20/2012", "02/20/2012", 3)]
+    [TestCase("01/20/2010", "02/20/2011", 0)]
+    public async Task GetUserReports(DateTime from, DateTime to, int expectedCount)
+    {
+      //arrange
+      var userRepository = Substitute.For<IUserRepository>();
+      var service = new MyService(userRepository);
+      List<UserEntity> users = CreateUserList();
 
-		}
+      //expect
+      var mock = users.BuildMock();
+      userRepository.GetQueryable().Returns(mock);
+      //act
+      var result = await service.GetUserReports(from, to);
+      //assert
+      Assert.AreEqual(expectedCount, result.Count);
+    }
 
-        [TestCase("01/20/2012", "06/20/2018",5)]
-		[TestCase("01/20/2012", "06/20/2012",4)]
-		[TestCase("01/20/2012", "02/20/2012",3)]
-		[TestCase("01/20/2010", "02/20/2011",0)]
-		public async Task GetUserReports(DateTime from, DateTime to, int expectedCount)
-		{
-            //arrange
-		    var userRepository = Substitute.For<IUserRepository>();
-		    var service = new MyService(userRepository);
-            List<UserEntity> users = CreateUserList();
+    [TestCase("01/20/2012", "06/20/2018", 5)]
+    [TestCase("01/20/2012", "06/20/2012", 4)]
+    [TestCase("01/20/2012", "02/20/2012", 3)]
+    [TestCase("01/20/2010", "02/20/2011", 0)]
+    public async Task GetUserReports_AutoMap(DateTime from, DateTime to, int expectedCount)
+    {
+      //arrange
+      List<UserEntity> users = CreateUserList();
 
-            //expect
-            var mock = users.BuildMock();
-			userRepository.GetQueryable().Returns(mock);
-			//act
-			var result = await service.GetUserReports(from, to);
-			//assert
-			Assert.AreEqual(expectedCount, result.Count);
-		}
+      var mock = users.AsQueryable().BuildMockDbSet();
+      var userRepository = new TestDbSetRepository(mock);
+      var service = new MyService(userRepository);
+      //act
+      var result = await service.GetUserReportsAutoMap(from, to);
+      //assert
+      Assert.AreEqual(expectedCount, result.Count);
 
-        [TestCase("01/20/2012", "06/20/2018", 5)]
-        [TestCase("01/20/2012", "06/20/2012", 4)]
-        [TestCase("01/20/2012", "02/20/2012", 3)]
-        [TestCase("01/20/2010", "02/20/2011", 0)]
-        public async Task GetUserReports_AutoMap(DateTime from, DateTime to, int expectedCount)
-        {
-            //arrange
-            List<UserEntity> users = CreateUserList();
+    }
 
-            var mock = users.AsQueryable().BuildMockDbSet();
-            var userRepository = new TestDbSetRepository(mock);
-            var service = new MyService(userRepository);
-            //act
-            var result = await service.GetUserReportsAutoMap(from, to);
-            //assert
-            Assert.AreEqual(expectedCount, result.Count);
+    [TestCase("01/20/2012", "06/20/2018", 5)]
+    [TestCase("01/20/2012", "06/20/2012", 4)]
+    [TestCase("01/20/2012", "02/20/2012", 3)]
+    [TestCase("01/20/2010", "02/20/2011", 0)]
+    public async Task GetUserReports_AutoMap_FromDbSetCreatedFromCollection(DateTime from, DateTime to, int expectedCount)
+    {
+      //arrange
+      List<UserEntity> users = CreateUserList();
 
-        }
+      var mock = users.BuildMockDbSet();
+      var userRepository = new TestDbSetRepository(mock);
+      var service = new MyService(userRepository);
+      //act
+      var result = await service.GetUserReportsAutoMap(from, to);
+      //assert
+      Assert.AreEqual(expectedCount, result.Count);
 
-        [TestCase("01/20/2012", "06/20/2018", 5)]
-        [TestCase("01/20/2012", "06/20/2012", 4)]
-        [TestCase("01/20/2012", "02/20/2012", 3)]
-        [TestCase("01/20/2010", "02/20/2011", 0)]
-        public async Task GetUserReports_AutoMap_FromDbSetCreatedFromCollection(DateTime from, DateTime to, int expectedCount)
-        {
-            //arrange
-            List<UserEntity> users = CreateUserList();
+    }
 
-            var mock = users.BuildMockDbSet();
-            var userRepository = new TestDbSetRepository(mock);
-            var service = new MyService(userRepository);
-            //act
-            var result = await service.GetUserReportsAutoMap(from, to);
-            //assert
-            Assert.AreEqual(expectedCount, result.Count);
-
-        }
-
-        [TestCase("AnyFirstName", "AnyExistLastName", "01/20/2012", "Users with DateOfBirth more than limit")]
-        [TestCase("ExistFirstName", "AnyExistLastName", "02/20/2012", "User with FirstName already exist")]
-        [TestCase("AnyFirstName", "ExistLastName", "01/20/2012", "User already exist")]
-        public void DbSetCreateUserIfNotExist(string firstName, string lastName, DateTime dateOfBirth, string expectedError)
-        {
-            //arrange
-            var users = new List<UserEntity>
+    [TestCase("AnyFirstName", "AnyExistLastName", "01/20/2012", "Users with DateOfBirth more than limit")]
+    [TestCase("ExistFirstName", "AnyExistLastName", "02/20/2012", "User with FirstName already exist")]
+    [TestCase("AnyFirstName", "ExistLastName", "01/20/2012", "User already exist")]
+    public void DbSetCreateUserIfNotExist(string firstName, string lastName, DateTime dateOfBirth, string expectedError)
+    {
+      //arrange
+      var users = new List<UserEntity>
             {
                 new UserEntity{LastName = "ExistLastName", DateOfBirth = DateTime.Parse("01/20/2012",UsCultureInfo.DateTimeFormat)},
                 new UserEntity{FirstName = "ExistFirstName"},
@@ -113,24 +113,24 @@ namespace MockQueryable.Sample
                 new UserEntity{DateOfBirth = DateTime.Parse("01/20/2012",UsCultureInfo.DateTimeFormat)},
                 new UserEntity{DateOfBirth = DateTime.Parse("01/20/2012",UsCultureInfo.DateTimeFormat)},
             };
-            var mock = users.AsQueryable().BuildMockDbSet();
-            var userRepository = new TestDbSetRepository(mock);
-            var service = new MyService(userRepository);
-            //act
-            var ex = Assert.ThrowsAsync<ApplicationException>(() => service.CreateUserIfNotExist(firstName, lastName, dateOfBirth));
-            //assert
-            Assert.AreEqual(expectedError, ex.Message);
+      var mock = users.AsQueryable().BuildMockDbSet();
+      var userRepository = new TestDbSetRepository(mock);
+      var service = new MyService(userRepository);
+      //act
+      var ex = Assert.ThrowsAsync<ApplicationException>(() => service.CreateUserIfNotExist(firstName, lastName, dateOfBirth));
+      //assert
+      Assert.AreEqual(expectedError, ex.Message);
 
-        }
+    }
 
 
-        [TestCase("AnyFirstName", "AnyExistLastName", "01/20/2012", "Users with DateOfBirth more than limit")]
-        [TestCase("ExistFirstName", "AnyExistLastName", "02/20/2012", "User with FirstName already exist")]
-        [TestCase("AnyFirstName", "ExistLastName", "01/20/2012", "User already exist")]
-        public void DbSetCreatedFromCollectionCreateUserIfNotExist(string firstName, string lastName, DateTime dateOfBirth, string expectedError)
-        {
-            //arrange
-            var users = new List<UserEntity>
+    [TestCase("AnyFirstName", "AnyExistLastName", "01/20/2012", "Users with DateOfBirth more than limit")]
+    [TestCase("ExistFirstName", "AnyExistLastName", "02/20/2012", "User with FirstName already exist")]
+    [TestCase("AnyFirstName", "ExistLastName", "01/20/2012", "User already exist")]
+    public void DbSetCreatedFromCollectionCreateUserIfNotExist(string firstName, string lastName, DateTime dateOfBirth, string expectedError)
+    {
+      //arrange
+      var users = new List<UserEntity>
             {
                 new UserEntity{LastName = "ExistLastName", DateOfBirth = DateTime.Parse("01/20/2012",UsCultureInfo.DateTimeFormat)},
                 new UserEntity{FirstName = "ExistFirstName"},
@@ -138,277 +138,301 @@ namespace MockQueryable.Sample
                 new UserEntity{DateOfBirth = DateTime.Parse("01/20/2012",UsCultureInfo.DateTimeFormat)},
                 new UserEntity{DateOfBirth = DateTime.Parse("01/20/2012",UsCultureInfo.DateTimeFormat)},
             };
-            var mock = users.BuildMockDbSet();
-            var userRepository = new TestDbSetRepository(mock);
-            var service = new MyService(userRepository);
-            //act
-            var ex = Assert.ThrowsAsync<ApplicationException>(() => service.CreateUserIfNotExist(firstName, lastName, dateOfBirth));
-            //assert
-            Assert.AreEqual(expectedError, ex.Message);
+      var mock = users.BuildMockDbSet();
+      var userRepository = new TestDbSetRepository(mock);
+      var service = new MyService(userRepository);
+      //act
+      var ex = Assert.ThrowsAsync<ApplicationException>(() => service.CreateUserIfNotExist(firstName, lastName, dateOfBirth));
+      //assert
+      Assert.AreEqual(expectedError, ex.Message);
 
-        }
+    }
 
-        [TestCase("AnyFirstName", "ExistLastName", "01/20/2012")]
-        public async Task DbSetCreateUser(string firstName, string lastName, DateTime dateOfBirth)
-        {
-            //arrange
-            var userEntities = new List<UserEntity>();
-            var mock = userEntities.AsQueryable().BuildMockDbSet();
-            mock.AddAsync(Arg.Any<UserEntity>())
-                .Returns(info => null)
-                .AndDoes(info => userEntities.Add(info.Arg<UserEntity>()));
-            var userRepository = new TestDbSetRepository(mock);
-            var service = new MyService(userRepository);
-            //act
-            await service.CreateUserIfNotExist(firstName, lastName, dateOfBirth);
-            // assert
-            var entity = mock.Single();
-            Assert.AreEqual(firstName, entity.FirstName);
-            Assert.AreEqual(lastName, entity.LastName);
-            Assert.AreEqual(dateOfBirth, entity.DateOfBirth);
-        }
+    [TestCase("AnyFirstName", "ExistLastName", "01/20/2012")]
+    public async Task DbSetCreateUser(string firstName, string lastName, DateTime dateOfBirth)
+    {
+      //arrange
+      var userEntities = new List<UserEntity>();
+      var mock = userEntities.AsQueryable().BuildMockDbSet();
+      mock.AddAsync(Arg.Any<UserEntity>())
+          .Returns(info => null)
+          .AndDoes(info => userEntities.Add(info.Arg<UserEntity>()));
+      var userRepository = new TestDbSetRepository(mock);
+      var service = new MyService(userRepository);
+      //act
+      await service.CreateUserIfNotExist(firstName, lastName, dateOfBirth);
+      // assert
+      var entity = mock.Single();
+      Assert.AreEqual(firstName, entity.FirstName);
+      Assert.AreEqual(lastName, entity.LastName);
+      Assert.AreEqual(dateOfBirth, entity.DateOfBirth);
+    }
 
-        [TestCase("AnyFirstName", "ExistLastName", "01/20/2012")]
-        public async Task DbSetCreatedFromCollectionCreateUser(string firstName, string lastName, DateTime dateOfBirth)
-        {
-            //arrange
-            var userEntities = new List<UserEntity>();
-            var mock = userEntities.BuildMockDbSet();
-            mock.AddAsync(Arg.Any<UserEntity>())
-                .Returns(info => null)
-                .AndDoes(info => userEntities.Add(info.Arg<UserEntity>()));
-            var userRepository = new TestDbSetRepository(mock);
-            var service = new MyService(userRepository);
-            //act
-            await service.CreateUserIfNotExist(firstName, lastName, dateOfBirth);
-            // assert
-            var entity = mock.Single();
-            Assert.AreEqual(firstName, entity.FirstName);
-            Assert.AreEqual(lastName, entity.LastName);
-            Assert.AreEqual(dateOfBirth, entity.DateOfBirth);
-        }
+    [TestCase("AnyFirstName", "ExistLastName", "01/20/2012")]
+    public async Task DbSetCreatedFromCollectionCreateUser(string firstName, string lastName, DateTime dateOfBirth)
+    {
+      //arrange
+      var userEntities = new List<UserEntity>();
+      var mock = userEntities.BuildMockDbSet();
+      mock.AddAsync(Arg.Any<UserEntity>())
+          .Returns(info => null)
+          .AndDoes(info => userEntities.Add(info.Arg<UserEntity>()));
+      var userRepository = new TestDbSetRepository(mock);
+      var service = new MyService(userRepository);
+      //act
+      await service.CreateUserIfNotExist(firstName, lastName, dateOfBirth);
+      // assert
+      var entity = mock.Single();
+      Assert.AreEqual(firstName, entity.FirstName);
+      Assert.AreEqual(lastName, entity.LastName);
+      Assert.AreEqual(dateOfBirth, entity.DateOfBirth);
+    }
 
-        [TestCase("01/20/2012", "06/20/2018", 5)]
-        [TestCase("01/20/2012", "06/20/2012", 4)]
-        [TestCase("01/20/2012", "02/20/2012", 3)]
-        [TestCase("01/20/2010", "02/20/2011", 0)]
-        public async Task DbSetGetUserReports(DateTime from, DateTime to, int expectedCount)
-        {
-            //arrange
-            var users = CreateUserList();
+    [TestCase("01/20/2012", "06/20/2018", 5)]
+    [TestCase("01/20/2012", "06/20/2012", 4)]
+    [TestCase("01/20/2012", "02/20/2012", 3)]
+    [TestCase("01/20/2010", "02/20/2011", 0)]
+    public async Task DbSetGetUserReports(DateTime from, DateTime to, int expectedCount)
+    {
+      //arrange
+      var users = CreateUserList();
 
-            var mock = users.AsQueryable().BuildMockDbSet();
-            var userRepository = new TestDbSetRepository(mock);
-            var service = new MyService(userRepository);
-            //act
-            var result = await service.GetUserReports(from, to);
-            //assert
-            Assert.AreEqual(expectedCount, result.Count);
-        }
+      var mock = users.AsQueryable().BuildMockDbSet();
+      var userRepository = new TestDbSetRepository(mock);
+      var service = new MyService(userRepository);
+      //act
+      var result = await service.GetUserReports(from, to);
+      //assert
+      Assert.AreEqual(expectedCount, result.Count);
+    }
 
-        [TestCase("01/20/2012", "06/20/2018", 5)]
-        [TestCase("01/20/2012", "06/20/2012", 4)]
-        [TestCase("01/20/2012", "02/20/2012", 3)]
-        [TestCase("01/20/2010", "02/20/2011", 0)]
-        public async Task DbSetCreatedFromCollectionGetUserReports(DateTime from, DateTime to, int expectedCount)
-        {
-            //arrange
-            var users = CreateUserList();
+    [TestCase("01/20/2012", "06/20/2018", 5)]
+    [TestCase("01/20/2012", "06/20/2012", 4)]
+    [TestCase("01/20/2012", "02/20/2012", 3)]
+    [TestCase("01/20/2010", "02/20/2011", 0)]
+    public async Task DbSetCreatedFromCollectionGetUserReports(DateTime from, DateTime to, int expectedCount)
+    {
+      //arrange
+      var users = CreateUserList();
 
-            var mock = users.BuildMockDbSet();
-            var userRepository = new TestDbSetRepository(mock);
-            var service = new MyService(userRepository);
-            //act
-            var result = await service.GetUserReports(from, to);
-            //assert
-            Assert.AreEqual(expectedCount, result.Count);
-        }
+      var mock = users.BuildMockDbSet();
+      var userRepository = new TestDbSetRepository(mock);
+      var service = new MyService(userRepository);
+      //act
+      var result = await service.GetUserReports(from, to);
+      //assert
+      Assert.AreEqual(expectedCount, result.Count);
+    }
 
-        [Test]
-        public async Task DbSetGetAllUserEntity()
-        {
-            //arrange
-            var users = CreateUserList();
-            var mock = users.AsQueryable().BuildMockDbSet();
-            var userRepository = new TestDbSetRepository(mock);
-            //act
-            var result = await userRepository.GetAll();
-            //assert
-            Assert.AreEqual(users.Count, result.Count);
-        }
+    [Test]
+    public async Task DbSetGetAllUserEntity()
+    {
+      //arrange
+      var users = CreateUserList();
+      var mock = users.AsQueryable().BuildMockDbSet();
+      var userRepository = new TestDbSetRepository(mock);
+      //act
+      var result = await userRepository.GetAll();
+      //assert
+      Assert.AreEqual(users.Count, result.Count);
+    }
 
-        [Test]
-        public async Task DbSetCreatedFromCollectionGetAllUserEntity()
-        {
-            //arrange
-            var users = CreateUserList();
-            var mock = users.BuildMockDbSet();
-            var userRepository = new TestDbSetRepository(mock);
-            //act
-            var result = await userRepository.GetAll();
-            //assert
-            Assert.AreEqual(users.Count, result.Count);
-        }
+    [Test]
+    public async Task DbSetCreatedFromCollectionGetAllUserEntity()
+    {
+      //arrange
+      var users = CreateUserList();
+      var mock = users.BuildMockDbSet();
+      var userRepository = new TestDbSetRepository(mock);
+      //act
+      var result = await userRepository.GetAll();
+      //assert
+      Assert.AreEqual(users.Count, result.Count);
+    }
 
-        [Test]
-        public async Task DbSetGetAllUserEntitiesAsync()
-        {
-            // arrange
-            var users = CreateUserList();
+    [Test]
+    public async Task DbSetGetAllUserEntitiesAsync()
+    {
+      // arrange
+      var users = CreateUserList();
 
-            var mockDbSet = users.AsQueryable().BuildMockDbSet();
-            var userRepository = new TestDbSetRepository(mockDbSet);
+      var mockDbSet = users.AsQueryable().BuildMockDbSet();
+      var userRepository = new TestDbSetRepository(mockDbSet);
 
-            // act
-            var result = await userRepository.GetAllAsync().ToListAsync();
+      // act
+      var result = await userRepository.GetAllAsync().ToListAsync();
 
-            // assert
-            Assert.AreEqual(users.Count, result.Count);
-        }
-        
-        
-        [Test]
-        public async Task DbSetGetAllUserEntitiesAsync_ShouldReturnAllEntities_WhenSourceIsChanged()
-        {
-	        // arrange
-	        var users = new List<UserEntity>();
+      // assert
+      Assert.AreEqual(users.Count, result.Count);
+    }
 
-	        var mockDbSet = users.AsQueryable().BuildMockDbSet();
-	        var userRepository = new TestDbSetRepository(mockDbSet);
+    [Test]
+    public async Task DbSetGetAllUserEntitiesAsync_ShouldReturnAllEntities_WhenSourceIsChanged()
+    {
+      // arrange
+      var users = new List<UserEntity>();
 
-	        // act
-	        var result1 = await userRepository.GetAllAsync().ToListAsync();
-	        users.AddRange(CreateUserList());
-	        var result2 = await userRepository.GetAllAsync().ToListAsync();
+      var mockDbSet = users.AsQueryable().BuildMockDbSet();
+      var userRepository = new TestDbSetRepository(mockDbSet);
 
-	        // assert
-	        Assert.AreEqual(0, result1.Count);
-	        Assert.AreEqual(users.Count, result2.Count);
-        }
+      // act
+      var result1 = await userRepository.GetAllAsync().ToListAsync();
+      users.AddRange(CreateUserList());
+      var result2 = await userRepository.GetAllAsync().ToListAsync();
 
-        [Test]
-        public async Task DbSetCreatedFromCollectionGetAllUserEntitiesAsync()
-        {
-            // arrange
-            var users = CreateUserList();
+      // assert
+      Assert.AreEqual(0, result1.Count);
+      Assert.AreEqual(users.Count, result2.Count);
+    }
 
-            var mockDbSet = users.BuildMockDbSet();
-            var userRepository = new TestDbSetRepository(mockDbSet);
+    [Test]
+    public async Task DbSetCreatedFromCollectionGetAllUserEntitiesAsync()
+    {
+      // arrange
+      var users = CreateUserList();
 
-            // act
-            var result = await userRepository.GetAllAsync().ToListAsync();
+      var mockDbSet = users.BuildMockDbSet();
+      var userRepository = new TestDbSetRepository(mockDbSet);
 
-            // assert
-            Assert.AreEqual(users.Count, result.Count);
-        }
+      // act
+      var result = await userRepository.GetAllAsync().ToListAsync();
 
-        [Test]
-        public async Task DbSetGetOneUserTntityAsync()
-        {
-            // arrange
-            var users = CreateUserList();
+      // assert
+      Assert.AreEqual(users.Count, result.Count);
+    }
 
-            var mockDbSet = users.AsQueryable().BuildMockDbSet();
-            var userRepository = new TestDbSetRepository(mockDbSet);
+    [Test]
+    public async Task DbSetGetOneUserTntityAsync()
+    {
+      // arrange
+      var users = CreateUserList();
 
-            // act
-            var result = await userRepository.GetAllAsync()
-                .Where(user => user.FirstName == "FirstName1")
-                .FirstOrDefaultAsync();
+      var mockDbSet = users.AsQueryable().BuildMockDbSet();
+      var userRepository = new TestDbSetRepository(mockDbSet);
 
-            // assert
-            Assert.AreEqual(users.First(), result);
-        }
+      // act
+      var result = await userRepository.GetAllAsync()
+          .Where(user => user.FirstName == "FirstName1")
+          .FirstOrDefaultAsync();
 
-        [Test]
-        public async Task DbSetCreatedFromCollectionGetOneUserTntityAsync()
-        {
-            // arrange
-            var users = CreateUserList();
+      // assert
+      Assert.AreEqual(users.First(), result);
+    }
 
-            var mockDbSet = users.BuildMockDbSet();
-            var userRepository = new TestDbSetRepository(mockDbSet);
+    [Test]
+    public async Task DbSetCreatedFromCollectionGetOneUserTntityAsync()
+    {
+      // arrange
+      var users = CreateUserList();
 
-            // act
-            var result = await userRepository.GetAllAsync()
-                                             .Where(user => user.FirstName == "FirstName1")
-                                             .FirstOrDefaultAsync();
+      var mockDbSet = users.BuildMockDbSet();
+      var userRepository = new TestDbSetRepository(mockDbSet);
 
-            // assert
-            Assert.AreEqual(users.First(), result);
-        }
+      // act
+      var result = await userRepository.GetAllAsync()
+                                       .Where(user => user.FirstName == "FirstName1")
+                                       .FirstOrDefaultAsync();
 
+      // assert
+      Assert.AreEqual(users.First(), result);
+    }
 
-        [Test]
-        public async Task DbSetCreatedFromCollectionExecuteDeleteAsync()
-        {
-            // arrange
-            var userId = Guid.NewGuid();
-            var users = CreateUserList(userId);
+    [Test]
+    public async Task DbSetCreatedFromCollection_ExecuteDeleteAsync_NoInterceptionEntityNotRemoved()
+    {
+      // arrange
+      var userId = Guid.NewGuid();
+      var users = CreateUserList(userId);
 
-            var mockDbSet = users.BuildMockDbSet();
-            var userRepository = new TestDbSetRepository(mockDbSet);
+      var mockDbSet = users.BuildMockDbSet();
+      var userRepository = new TestDbSetRepository(mockDbSet);
 
-            // act
-            var count = await userRepository.DeleteUserAsync(userId);
+      // act
+      var count = await userRepository.DeleteUserAsync(userId);
 
-            // assert
-            Assert.AreEqual(1, count);
+      // assert
+      Assert.AreEqual(1, count);
+      var updatedUsers = await userRepository.GetAllAsync().ToListAsync();
+      Assert.IsNotNull(updatedUsers.SingleOrDefault(x => x.Id == userId));
+    }
 
-        }
+    [Test]
+    public async Task DbSetCreatedFromCollection_ExecuteDeleteAsync_InterceptionEntityRemoved()
+    {
+      // arrange
+      var userId = Guid.NewGuid();
+      var users = CreateUserList(userId);
 
-        [Test]
-        public async Task DbSetCreatedFromCollectionExecuteDeleteAsync_ShouldReturnZero()
-        {
-            // arrange
-            var userId = Guid.NewGuid();
-            var users = CreateUserList(userId);
+      var mockDbSet = users.BuildMockDbSetWithInterceptedExecuteDelete();
+      var userRepository = new TestDbSetRepository(mockDbSet);
 
-            var mockDbSet = users.BuildMockDbSet();
-            var userRepository = new TestDbSetRepository(mockDbSet);
+      // act
+      var count = await userRepository.DeleteUserAsync(userId);
 
-            //act
-            var count = await userRepository.DeleteUserAsync(Guid.NewGuid());
+      // assert
+      Assert.AreEqual(1, count);
+      var updatedUsers = await userRepository.GetAllAsync().ToListAsync();
+      Assert.IsNull(updatedUsers.SingleOrDefault(x => x.Id == userId));
+    }
 
-            // assert
-            Assert.AreEqual(0, count);
-        }
+    [Test]
+    public async Task DbSetCreatedFromCollectionExecuteDeleteAsync_ShouldReturnZero()
+    {
+      // arrange
+      var userId = Guid.NewGuid();
+      var users = CreateUserList(userId);
 
-        [Test]
-        public async Task DbSetCreatedFromCollectionExecuteUpdateAsync()
-        {
-            // arrange
-            var userId = Guid.NewGuid();
-            var users = CreateUserList(userId);
+      var mockDbSet = users.BuildMockDbSet();
+      var userRepository = new TestDbSetRepository(mockDbSet);
 
-            var mockDbSet = users.BuildMockDbSet();
-            var userRepository = new TestDbSetRepository(mockDbSet);
-            
-            //act
-            var count = await userRepository.UpdateFirstNameByIdAsync(userId, "Unit Test");
+      //act
+      var count = await userRepository.DeleteUserAsync(Guid.NewGuid());
 
-            //assert
-            Assert.AreEqual(1, count);
-        }
+      // assert
+      Assert.AreEqual(0, count);
+    }
 
-        [Test]
-        public async Task DbSetCreatedFromCollectionExecuteUpdateAsync_ShouldReturnZero()
-        {
-            // arrange
-            var userId = Guid.NewGuid();
-            var users = CreateUserList(userId);
+    [Test]
+    public async Task DbSetCreatedFromCollectionExecuteUpdateAsync()
+    {
+      // arrange
+      var userId = Guid.NewGuid();
+      var users = CreateUserList(userId);
 
-            var mockDbSet = users.BuildMockDbSet();
-            var userRepository = new TestDbSetRepository(mockDbSet);
+      var mockDbSet = users.BuildMockDbSet();
+      var userRepository = new TestDbSetRepository(mockDbSet);
 
-            //act
-            var count = await userRepository.UpdateFirstNameByIdAsync(Guid.NewGuid(), "Unit Test");
+      //act
+      var count = await userRepository.UpdateFirstAndLastNameByIdAsync(userId, "Unit Test");
 
-            //assert
-            Assert.AreEqual(0, count);
-        }
+      //assert
+      Assert.AreEqual(1, count);
+      var user = users.Single(x => x.Id == userId);
+      user.FirstName = "Unit Test";
+      user.LastName = "Unit Test";
+    }
 
-        private static List<UserEntity> CreateUserList(Guid? userId = null) => new List<UserEntity>
+    [Test]
+    public async Task DbSetCreatedFromCollectionExecuteUpdateAsync_ShouldReturnZero()
+    {
+      // arrange
+      var userId = Guid.NewGuid();
+      var users = CreateUserList(userId);
+
+      var mockDbSet = users.BuildMockDbSet();
+      var userRepository = new TestDbSetRepository(mockDbSet);
+
+      //act
+      var count = await userRepository.UpdateFirstAndLastNameByIdAsync(Guid.NewGuid(), "Unit Test");
+
+      //assert
+      Assert.AreEqual(0, count);
+      var user = users.Single(x => x.Id == userId);
+      user.FirstName = "Unit Test";
+      user.LastName = "Unit Test";
+    }
+
+    private static List<UserEntity> CreateUserList(Guid? userId = null) => new List<UserEntity>
         {
             new UserEntity { Id = userId ?? Guid.NewGuid(), FirstName = "FirstName1", LastName = "LastName", DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat) },
             new UserEntity { Id = Guid.NewGuid(), FirstName = "FirstName2", LastName = "LastName", DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat) },
@@ -417,5 +441,5 @@ namespace MockQueryable.Sample
             new UserEntity { Id = Guid.NewGuid(), FirstName = "FirstName5", LastName = "LastName", DateOfBirth = DateTime.Parse("01/20/2018", UsCultureInfo.DateTimeFormat) },
         };
 
-    }
+  }
 }

--- a/src/MockQueryable/MockQueryable.Sample/TestDbSetRepository.cs
+++ b/src/MockQueryable/MockQueryable.Sample/TestDbSetRepository.cs
@@ -6,43 +6,44 @@ using System.Threading.Tasks;
 
 namespace MockQueryable.Sample
 {
-    public class TestDbSetRepository : IUserRepository
+  public class TestDbSetRepository : IUserRepository
+  {
+    private readonly DbSet<UserEntity> _dbSet;
+
+    public TestDbSetRepository(DbSet<UserEntity> dbSet)
     {
-        private readonly DbSet<UserEntity> _dbSet;
-
-        public TestDbSetRepository(DbSet<UserEntity> dbSet)
-        {
-            _dbSet = dbSet;
-        }
-        public IQueryable<UserEntity> GetQueryable()
-        {
-            return _dbSet;
-        }
-
-        public async Task CreateUser(UserEntity user)
-        {
-            await _dbSet.AddAsync(user);
-        }
-
-        public async Task<List<UserEntity>> GetAll() {
-            return await _dbSet.ToListAsync();
-        }
-
-        public IAsyncEnumerable<UserEntity> GetAllAsync()
-        {
-            return _dbSet.AsAsyncEnumerable();
-        }
-
-        public async Task<int> DeleteUserAsync(Guid id)
-        {
-            return await _dbSet.Where(x => x.Id == id)
-                .ExecuteDeleteAsync();
-        }
-
-        public async Task<int> UpdateFirstNameByIdAsync(Guid id, string firstName)
-        {
-            return await _dbSet.Where(x => x.Id == id)
-                .ExecuteUpdateAsync(opt => opt.SetProperty(x => x.FirstName, firstName));
-        }
+      _dbSet = dbSet;
     }
+    public IQueryable<UserEntity> GetQueryable()
+    {
+      return _dbSet;
+    }
+
+    public async Task CreateUser(UserEntity user)
+    {
+      await _dbSet.AddAsync(user);
+    }
+
+    public async Task<List<UserEntity>> GetAll()
+    {
+      return await _dbSet.ToListAsync();
+    }
+
+    public IAsyncEnumerable<UserEntity> GetAllAsync()
+    {
+      return _dbSet.AsAsyncEnumerable();
+    }
+
+    public async Task<int> DeleteUserAsync(Guid id)
+    {
+      return await _dbSet.Where(x => x.Id == id)
+          .ExecuteDeleteAsync();
+    }
+
+    public async Task<int> UpdateFirstAndLastNameByIdAsync(Guid id, string firstName)
+    {
+      return await _dbSet.Where(x => x.Id == id)
+          .ExecuteUpdateAsync(opt => opt.SetProperty(x => x.FirstName, firstName).SetProperty(x => x.LastName, firstName));
+    }
+  }
 }


### PR DESCRIPTION
# PR Details

According to [this comment ](https://github.com/romantitov/MockQueryable/issues/66#issuecomment-2370681102) in the issue, ExecuteUpdateAsync and ExecuteDeleteAsync are now mocked, but the actual test data set is not modified.
This PR updates the test data set for `ExecuteUpdateAsync` and removes entities for `ExecuteDeleteAsync` (when using the new overload `BuildMockDbSetWithInterceptedExecuteDelete`).

## Description

### ExecuteUpdateAsync

The new method `TestAsyncEnumerableEfCore<T>.ApplyUpdateChangesToDbSet` extracts the update lambda expression and applies the changes to all affected items. The affected items are the previously filtered entities.

### ExecuteDeleteAsync

Applying changes for entity removal was more challenging than for updates. The existing `BuildMockDbSet` methods accept an `IQueryable<TEntity>` or `IEnumerable<TEntity>` as the data set, which is suitable for most cases since the data set typically does not need to be modified.

However, for `ExecuteDeleteAsync`, entities must be removed, and instead of returning a new data set, only the count of removed items is returned. Therefore, the original data set must be modified.

To address this and preserve the existing methods, two new methods are introduced:
- `BuildMockDbSetWithInterceptedExecuteDelete` for `ICollection<TEntity>`
- `BuildMockDbSetWithInterceptedExecuteDelete` for `DbSet<TEntity>`

Additionally, an optional callback is implemented, which removes the affected entity when `ExecuteDeleteAsync` is called, directly modifying the data set. This callback is used in the above mentioned two methods.

## Related Issue

https://github.com/romantitov/MockQueryable/issues/66

## How Has This Been Tested

- Created new unit tests for all three variants to ensure the feature `BuildMockDbSetWithInterceptedExecuteDelete` is working as expected.
- Updated existing tests for `ExecuteUpdateAsync` to ensure that the changes were applied to the data set.
- Keep the original `BuildMockDbSet` as they are, to avoid breaking changes (also since using and testing `ExecuteDeleteAsync` will be rather the exception than the rule).
- Ensured all new unit tests passed and that existing tests remained unaffected.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
