### PR TITLE
#88 Fix `.AsQueryable` calls to the test data set

### DIFF
--- a/src/MockQueryable/MockQueryable.FakeItEasy/FakeItEasyExtensions.cs
+++ b/src/MockQueryable/MockQueryable.FakeItEasy/FakeItEasyExtensions.cs
@@ -10,95 +10,95 @@ using System.Threading.Tasks;
 
 namespace MockQueryable.FakeItEasy
 {
-  public static class FakeItEasyExtensions
-  {
-
-    /// <summary>
-    /// This method allows you to create a mock DbSet for testing purposes.
-    /// It is particularly useful when you want to simulate the behavior of Entity Framework Core's DbSet
-    /// with custom expression handling, such as for testing LINQ queries or database operations.
-    /// The method takes an IQueryable of the entity type and returns a mocked DbSet that implements
-    /// both IAsyncEnumerable and IQueryable interfaces, allowing for asynchronous enumeration
-    /// and LINQ query capabilities.
-    /// </summary>
-    /// <typeparam name="TEntity">
-    /// The type of the entity that the DbSet will represent.
-    /// </typeparam>
-    public static DbSet<TEntity> BuildMockDbSet<TEntity>(this ICollection<TEntity> data) where TEntity : class
-    {
-      return BuildMockDbSet<TEntity, TestExpressionVisitor>(data);
-    }
-
-    /// <summary>
-    /// This method allows you to create a mock DbSet for testing purposes.
-    /// It is particularly useful when you want to simulate the behavior of Entity Framework Core's DbSet
-    /// with custom expression handling, such as for testing LINQ queries or database operations.
-    /// The method takes an IQueryable of the entity type and returns a mocked DbSet that implements
-    /// both IAsyncEnumerable and IQueryable interfaces, allowing for asynchronous enumeration
-    /// and LINQ query capabilities.
-    /// </summary>
-    /// <typeparam name="TEntity">
-    /// The type of the entity that the DbSet will represent.
-    /// </typeparam>
-    /// <typeparam name="TExpressionVisitor">
-    /// The type of the expression visitor that will be used to process LINQ expressions.
-    /// Can be used to mock EF Core specific expression handling, such as for ILike expressions.
-    /// </typeparam>
-    public static DbSet<TEntity> BuildMockDbSet<TEntity, TExpressionVisitor>(this ICollection<TEntity> data)
-      where TEntity : class
-      where TExpressionVisitor : ExpressionVisitor, new()
-    {
-      var mock = A.Fake<DbSet<TEntity>>(d => d.Implements<IAsyncEnumerable<TEntity>>().Implements<IQueryable<TEntity>>());
-      var enumerable = new TestAsyncEnumerableEfCore<TEntity, TExpressionVisitor>(data, entity => data.Remove(entity));
-      mock.ConfigureQueryableCalls(enumerable, data.AsQueryable());
-      mock.ConfigureAsyncEnumerableCalls(enumerable);
-      mock.ConfigureDbSetCalls(data.AsQueryable());
-
-      if (mock is IAsyncEnumerable<TEntity> asyncEnumerable)
-      {
-        A.CallTo(() => asyncEnumerable.GetAsyncEnumerator(A<CancellationToken>.Ignored)).ReturnsLazily(() => enumerable.GetAsyncEnumerator());
-      }
-
-      return mock;
-    }
-
-    private static void ConfigureQueryableCalls<TEntity>(
-        this IQueryable<TEntity> mock,
-        IQueryProvider queryProvider,
-        IQueryable<TEntity> data) where TEntity : class
-    {
-      A.CallTo(() => mock.Provider).Returns(queryProvider);
-      A.CallTo(() => mock.Expression).Returns(data?.Expression);
-      A.CallTo(() => mock.ElementType).Returns(data?.ElementType);
-      A.CallTo(() => mock.GetEnumerator()).ReturnsLazily(() => data?.GetEnumerator());
-    }
-
-    private static void ConfigureAsyncEnumerableCalls<TEntity>(
-        this DbSet<TEntity> mock,
-        IAsyncEnumerable<TEntity> enumerable) where TEntity : class
-    {
-      A.CallTo(() => mock.GetAsyncEnumerator(A<CancellationToken>.Ignored))
-          .Returns(enumerable.GetAsyncEnumerator());
-    }
-
-    private static void ConfigureDbSetCalls<TEntity>(this DbSet<TEntity> mock, IQueryable<TEntity> data)
-      where TEntity : class
-    {
-      A.CallTo(() => mock.AsQueryable()).Returns(data.AsQueryable());
-      A.CallTo(() => mock.AsAsyncEnumerable()).ReturnsLazily(args => CreateAsyncMock(data));
-    }
-
-    private static async IAsyncEnumerable<TEntity> CreateAsyncMock<TEntity>(
-      this IEnumerable<TEntity> data)
-      where TEntity : class
+    public static class FakeItEasyExtensions
     {
 
-      foreach (var entity in data)
-      {
-        yield return entity;
-      }
+        /// <summary>
+        /// This method allows you to create a mock DbSet for testing purposes.
+        /// It is particularly useful when you want to simulate the behavior of Entity Framework Core's DbSet
+        /// with custom expression handling, such as for testing LINQ queries or database operations.
+        /// The method takes an IQueryable of the entity type and returns a mocked DbSet that implements
+        /// both IAsyncEnumerable and IQueryable interfaces, allowing for asynchronous enumeration
+        /// and LINQ query capabilities.
+        /// </summary>
+        /// <typeparam name="TEntity">
+        /// The type of the entity that the DbSet will represent.
+        /// </typeparam>
+        public static DbSet<TEntity> BuildMockDbSet<TEntity>(this ICollection<TEntity> data) where TEntity : class
+        {
+            return BuildMockDbSet<TEntity, TestExpressionVisitor>(data);
+        }
 
-      await Task.CompletedTask;
+        /// <summary>
+        /// This method allows you to create a mock DbSet for testing purposes.
+        /// It is particularly useful when you want to simulate the behavior of Entity Framework Core's DbSet
+        /// with custom expression handling, such as for testing LINQ queries or database operations.
+        /// The method takes an IQueryable of the entity type and returns a mocked DbSet that implements
+        /// both IAsyncEnumerable and IQueryable interfaces, allowing for asynchronous enumeration
+        /// and LINQ query capabilities.
+        /// </summary>
+        /// <typeparam name="TEntity">
+        /// The type of the entity that the DbSet will represent.
+        /// </typeparam>
+        /// <typeparam name="TExpressionVisitor">
+        /// The type of the expression visitor that will be used to process LINQ expressions.
+        /// Can be used to mock EF Core specific expression handling, such as for ILike expressions.
+        /// </typeparam>
+        public static DbSet<TEntity> BuildMockDbSet<TEntity, TExpressionVisitor>(this ICollection<TEntity> data)
+          where TEntity : class
+          where TExpressionVisitor : ExpressionVisitor, new()
+        {
+            var mock = A.Fake<DbSet<TEntity>>(d => d.Implements<IAsyncEnumerable<TEntity>>().Implements<IQueryable<TEntity>>());
+            var enumerable = new TestAsyncEnumerableEfCore<TEntity, TExpressionVisitor>(data, entity => data.Remove(entity));
+            mock.ConfigureQueryableCalls(enumerable, data.AsQueryable());
+            mock.ConfigureAsyncEnumerableCalls(enumerable);
+            mock.ConfigureDbSetCalls(data.AsQueryable());
+
+            if (mock is IAsyncEnumerable<TEntity> asyncEnumerable)
+            {
+                A.CallTo(() => asyncEnumerable.GetAsyncEnumerator(A<CancellationToken>.Ignored)).ReturnsLazily(() => enumerable.GetAsyncEnumerator());
+            }
+
+            return mock;
+        }
+
+        private static void ConfigureQueryableCalls<TEntity>(
+            this IQueryable<TEntity> mock,
+            IQueryProvider queryProvider,
+            IQueryable<TEntity> data) where TEntity : class
+        {
+            A.CallTo(() => mock.Provider).Returns(queryProvider);
+            A.CallTo(() => mock.Expression).Returns(data?.Expression);
+            A.CallTo(() => mock.ElementType).Returns(data?.ElementType);
+            A.CallTo(() => mock.GetEnumerator()).ReturnsLazily(() => data?.GetEnumerator());
+        }
+
+        private static void ConfigureAsyncEnumerableCalls<TEntity>(
+            this DbSet<TEntity> mock,
+            IAsyncEnumerable<TEntity> enumerable) where TEntity : class
+        {
+            A.CallTo(() => mock.GetAsyncEnumerator(A<CancellationToken>.Ignored))
+                .Returns(enumerable.GetAsyncEnumerator());
+        }
+
+        private static void ConfigureDbSetCalls<TEntity>(this DbSet<TEntity> mock, IQueryable<TEntity> data)
+          where TEntity : class
+        {
+            A.CallTo(() => mock.AsQueryable()).Returns(mock);
+            A.CallTo(() => mock.AsAsyncEnumerable()).ReturnsLazily(args => CreateAsyncMock(data));
+        }
+
+        private static async IAsyncEnumerable<TEntity> CreateAsyncMock<TEntity>(
+          this IEnumerable<TEntity> data)
+          where TEntity : class
+        {
+
+            foreach (var entity in data)
+            {
+                yield return entity;
+            }
+
+            await Task.CompletedTask;
+        }
     }
-  }
 }

--- a/src/MockQueryable/MockQueryable.Moq/MoqExtensions.cs
+++ b/src/MockQueryable/MockQueryable.Moq/MoqExtensions.cs
@@ -10,92 +10,90 @@ using System.Threading.Tasks;
 
 namespace MockQueryable.Moq
 {
-	public static class MoqExtensions
-	{
-        
-    /// <summary>
-    /// This method allows you to create a mock DbSet for testing purposes.
-    /// It is particularly useful when you want to simulate the behavior of Entity Framework Core's DbSet
-    /// with custom expression handling, such as for testing LINQ queries or database operations.
-    /// The method takes an IQueryable of the entity type and returns a mocked DbSet that implements
-    /// both IAsyncEnumerable and IQueryable interfaces, allowing for asynchronous enumeration
-    /// and LINQ query capabilities.
-    /// </summary>
-    /// <typeparam name="TEntity">
-    /// The type of the entity that the DbSet will represent.
-    /// </typeparam>
-    public static Mock<DbSet<TEntity>> BuildMockDbSet<TEntity>(this ICollection<TEntity> data) where TEntity : class
+    public static class MoqExtensions
     {
-      return BuildMockDbSet<TEntity, TestExpressionVisitor>(data);
+
+        /// <summary>
+        /// This method allows you to create a mock DbSet for testing purposes.
+        /// It is particularly useful when you want to simulate the behavior of Entity Framework Core's DbSet
+        /// with custom expression handling, such as for testing LINQ queries or database operations.
+        /// The method takes an IQueryable of the entity type and returns a mocked DbSet that implements
+        /// both IAsyncEnumerable and IQueryable interfaces, allowing for asynchronous enumeration
+        /// and LINQ query capabilities.
+        /// </summary>
+        /// <typeparam name="TEntity">
+        /// The type of the entity that the DbSet will represent.
+        /// </typeparam>
+        public static Mock<DbSet<TEntity>> BuildMockDbSet<TEntity>(this ICollection<TEntity> data) where TEntity : class
+        {
+            return BuildMockDbSet<TEntity, TestExpressionVisitor>(data);
+        }
+
+        /// <summary>
+        /// This method allows you to create a mock DbSet for testing purposes.
+        /// It is particularly useful when you want to simulate the behavior of Entity Framework Core's DbSet
+        /// with custom expression handling, such as for testing LINQ queries or database operations.
+        /// The method takes an IQueryable of the entity type and returns a mocked DbSet that implements
+        /// both IAsyncEnumerable and IQueryable interfaces, allowing for asynchronous enumeration
+        /// and LINQ query capabilities.
+        /// </summary>
+        /// <typeparam name="TEntity">
+        /// The type of the entity that the DbSet will represent.
+        /// </typeparam>
+        /// <typeparam name="TExpressionVisitor">
+        /// The type of the expression visitor that will be used to process LINQ expressions.
+        /// Can be used to mock EF Core specific expression handling, such as for ILike expressions.
+        /// </typeparam>
+        public static Mock<DbSet<TEntity>> BuildMockDbSet<TEntity, TExpressionVisitor>(this ICollection<TEntity> data)
+                where TEntity : class
+          where TExpressionVisitor : ExpressionVisitor, new()
+        {
+            var mock = new Mock<DbSet<TEntity>>();
+            var enumerable = new TestAsyncEnumerableEfCore<TEntity, TExpressionVisitor>(data, entity => data.Remove(entity));
+            mock.ConfigureAsyncEnumerableCalls(enumerable);
+            mock.As<IQueryable<TEntity>>().ConfigureQueryableCalls(enumerable, data.AsQueryable());
+            mock.As<IAsyncEnumerable<TEntity>>().Setup(x => x.GetAsyncEnumerator(It.IsAny<CancellationToken>())).Returns(() => enumerable.GetAsyncEnumerator());
+            mock.Setup(m => m.AsQueryable()).Returns(enumerable);
+
+            mock.ConfigureDbSetCalls(data.AsQueryable());
+            return mock;
+        }
+
+        private static void ConfigureDbSetCalls<TEntity>(this Mock<DbSet<TEntity>> mock, IQueryable<TEntity> data)
+                where TEntity : class
+        {
+            mock.Setup(m => m.AsQueryable()).Returns(mock.Object);
+            mock.Setup(m => m.AsAsyncEnumerable()).Returns(CreateAsyncMock(data));
+        }
+
+        private static void ConfigureQueryableCalls<TEntity>(
+          this Mock<IQueryable<TEntity>> mock,
+          IQueryProvider queryProvider,
+          IQueryable<TEntity> data) where TEntity : class
+        {
+            mock.Setup(m => m.Provider).Returns(queryProvider);
+            mock.Setup(m => m.Expression).Returns(data?.Expression);
+            mock.Setup(m => m.ElementType).Returns(data?.ElementType);
+            mock.Setup(m => m.GetEnumerator()).Returns(() => data?.GetEnumerator());
+        }
+
+        private static void ConfigureAsyncEnumerableCalls<TEntity>(
+          this Mock<DbSet<TEntity>> mock,
+          IAsyncEnumerable<TEntity> enumerable) where TEntity : class
+        {
+            mock.Setup(d => d.GetAsyncEnumerator(It.IsAny<CancellationToken>()))
+              .Returns(() => enumerable.GetAsyncEnumerator());
+        }
+
+        private static async IAsyncEnumerable<TEntity> CreateAsyncMock<TEntity>(IEnumerable<TEntity> data)
+            where TEntity : class
+        {
+            foreach (var entity in data)
+            {
+                yield return entity;
+            }
+
+            await Task.CompletedTask;
+        }
     }
-
-    /// <summary>
-    /// This method allows you to create a mock DbSet for testing purposes.
-    /// It is particularly useful when you want to simulate the behavior of Entity Framework Core's DbSet
-    /// with custom expression handling, such as for testing LINQ queries or database operations.
-    /// The method takes an IQueryable of the entity type and returns a mocked DbSet that implements
-    /// both IAsyncEnumerable and IQueryable interfaces, allowing for asynchronous enumeration
-    /// and LINQ query capabilities.
-    /// </summary>
-    /// <typeparam name="TEntity">
-    /// The type of the entity that the DbSet will represent.
-    /// </typeparam>
-    /// <typeparam name="TExpressionVisitor">
-    /// The type of the expression visitor that will be used to process LINQ expressions.
-    /// Can be used to mock EF Core specific expression handling, such as for ILike expressions.
-    /// </typeparam>
-    public static Mock<DbSet<TEntity>> BuildMockDbSet<TEntity, TExpressionVisitor>(this ICollection<TEntity> data)
-			where TEntity : class
-      where TExpressionVisitor : ExpressionVisitor, new()
-    {
-      var mock = new Mock<DbSet<TEntity>>();
-      var enumerable = new TestAsyncEnumerableEfCore<TEntity, TExpressionVisitor>(data, entity => data.Remove(entity));
-      mock.ConfigureAsyncEnumerableCalls(enumerable);
-      mock.As<IQueryable<TEntity>>().ConfigureQueryableCalls(enumerable, data.AsQueryable());
-      mock.As<IAsyncEnumerable<TEntity>>().Setup(x => x.GetAsyncEnumerator(It.IsAny<CancellationToken>())).Returns(() => enumerable.GetAsyncEnumerator());
-      mock.Setup(m => m.AsQueryable()).Returns(enumerable);
-
-      mock.ConfigureDbSetCalls(data.AsQueryable());
-      return mock;
-    }
-
-    private static void ConfigureDbSetCalls<TEntity>(this Mock<DbSet<TEntity>> mock, IQueryable<TEntity> data) 
-			where TEntity : class
-		{
-			mock.Setup(m => m.AsQueryable()).Returns(mock.Object);
-			mock.Setup(m => m.AsAsyncEnumerable()).Returns(CreateAsyncMock(data));
-		}
-
-    private static void ConfigureQueryableCalls<TEntity>(
-      this Mock<IQueryable<TEntity>> mock,
-      IQueryProvider queryProvider,
-      IQueryable<TEntity> data) where TEntity : class
-    {
-      mock.Setup(m => m.Provider).Returns(queryProvider);
-      mock.Setup(m => m.Expression).Returns(data?.Expression);
-      mock.Setup(m => m.ElementType).Returns(data?.ElementType);
-      mock.Setup(m => m.GetEnumerator()).Returns(() => data?.GetEnumerator());
-
-    }
-
-    private static void ConfigureAsyncEnumerableCalls<TEntity>(
-      this Mock<DbSet<TEntity>> mock,
-      IAsyncEnumerable<TEntity> enumerable) where TEntity : class
-    {
-      mock.Setup(d => d.GetAsyncEnumerator(It.IsAny<CancellationToken>()))
-        .Returns(() => enumerable.GetAsyncEnumerator());
-
-    }
-
-    private static async IAsyncEnumerable<TEntity> CreateAsyncMock<TEntity>(IEnumerable<TEntity> data)
-        where TEntity : class
-    {
-      foreach (var entity in data)
-      {
-        yield return entity;
-      }
-
-      await Task.CompletedTask;
-    }
-  }
 }

--- a/src/MockQueryable/MockQueryable.NSubstitute/NSubstituteExtensions.cs
+++ b/src/MockQueryable/MockQueryable.NSubstitute/NSubstituteExtensions.cs
@@ -10,105 +10,105 @@ using System.Threading.Tasks;
 
 namespace MockQueryable.NSubstitute
 {
-  public static class NSubstituteExtensions
-  {
-
-    /// <summary>
-    /// This method allows you to create a mock DbSet for testing purposes.
-    /// It is particularly useful when you want to simulate the behavior of Entity Framework Core's DbSet
-    /// with custom expression handling, such as for testing LINQ queries or database operations.
-    /// The method takes an IQueryable of the entity type and returns a mocked DbSet that implements
-    /// both IAsyncEnumerable and IQueryable interfaces, allowing for asynchronous enumeration
-    /// and LINQ query capabilities.
-    /// </summary>
-    /// <typeparam name="TEntity">
-    /// The type of the entity that the DbSet will represent.
-    /// </typeparam>
-    public static DbSet<TEntity> BuildMockDbSet<TEntity>(this ICollection<TEntity> data) where TEntity : class
+    public static class NSubstituteExtensions
     {
-      return BuildMockDbSet<TEntity, TestExpressionVisitor>(data);
+
+        /// <summary>
+        /// This method allows you to create a mock DbSet for testing purposes.
+        /// It is particularly useful when you want to simulate the behavior of Entity Framework Core's DbSet
+        /// with custom expression handling, such as for testing LINQ queries or database operations.
+        /// The method takes an IQueryable of the entity type and returns a mocked DbSet that implements
+        /// both IAsyncEnumerable and IQueryable interfaces, allowing for asynchronous enumeration
+        /// and LINQ query capabilities.
+        /// </summary>
+        /// <typeparam name="TEntity">
+        /// The type of the entity that the DbSet will represent.
+        /// </typeparam>
+        public static DbSet<TEntity> BuildMockDbSet<TEntity>(this ICollection<TEntity> data) where TEntity : class
+        {
+            return BuildMockDbSet<TEntity, TestExpressionVisitor>(data);
+        }
+
+        /// <summary>
+        /// This method allows you to create a mock DbSet for testing purposes.
+        /// It is particularly useful when you want to simulate the behavior of Entity Framework Core's DbSet
+        /// with custom expression handling, such as for testing LINQ queries or database operations.
+        /// The method takes an IQueryable of the entity type and returns a mocked DbSet that implements
+        /// both IAsyncEnumerable and IQueryable interfaces, allowing for asynchronous enumeration
+        /// and LINQ query capabilities.
+        /// </summary>
+        /// <typeparam name="TEntity">
+        /// The type of the entity that the DbSet will represent.
+        /// </typeparam>
+        /// <typeparam name="TExpressionVisitor">
+        /// The type of the expression visitor that will be used to process LINQ expressions.
+        /// Can be used to mock EF Core specific expression handling, such as for ILike expressions.
+        /// </typeparam>
+        public static DbSet<TEntity> BuildMockDbSet<TEntity, TExpressionVisitor>(this ICollection<TEntity> data)
+          where TEntity : class
+          where TExpressionVisitor : ExpressionVisitor, new()
+        {
+            var mock = Substitute.For<DbSet<TEntity>, IQueryable<TEntity>, IAsyncEnumerable<TEntity>>();
+            var enumerable = new TestAsyncEnumerableEfCore<TEntity, TExpressionVisitor>(data, entity => data.Remove(entity));
+
+            ConfigureAllCalls(mock, enumerable, data);
+
+            return mock;
+        }
+
+
+
+        private static void ConfigureAllCalls<TEntity, TExpressionVisitor>(
+            this DbSet<TEntity> mock,
+            TestAsyncEnumerableEfCore<TEntity, TExpressionVisitor> enumerable,
+            ICollection<TEntity> data)
+            where TEntity : class
+            where TExpressionVisitor : ExpressionVisitor, new()
+        {
+            mock.ConfigureAsyncEnumerableCalls(enumerable);
+            mock.ConfigureQueryableCalls(enumerable, data.AsQueryable());
+            mock.ConfigureDbSetCalls(data.AsQueryable());
+
+            if (mock is IAsyncEnumerable<TEntity> asyncEnumerable)
+            {
+                asyncEnumerable.GetAsyncEnumerator(Arg.Any<CancellationToken>()).Returns(args => enumerable.GetAsyncEnumerator());
+            }
+        }
+
+        private static void ConfigureQueryableCalls<TEntity>(
+          this IQueryable<TEntity> mock,
+          IQueryProvider queryProvider,
+          IQueryable<TEntity> data) where TEntity : class
+        {
+            mock.Provider.Returns(queryProvider);
+            mock.Expression.Returns(data?.Expression);
+            mock.ElementType.Returns(data?.ElementType);
+            mock.GetEnumerator().Returns(info => data?.GetEnumerator());
+        }
+
+        private static void ConfigureAsyncEnumerableCalls<TEntity>(
+          this DbSet<TEntity> mock,
+          IAsyncEnumerable<TEntity> enumerable) where TEntity : class
+        {
+            mock.GetAsyncEnumerator(Arg.Any<CancellationToken>()).Returns(args => enumerable.GetAsyncEnumerator());
+        }
+
+        private static void ConfigureDbSetCalls<TEntity>(this DbSet<TEntity> mock, IQueryable<TEntity> data)
+          where TEntity : class
+        {
+            mock.AsQueryable().Returns(mock);
+            mock.AsAsyncEnumerable().Returns(args => CreateAsyncMock(data));
+        }
+
+        private static async IAsyncEnumerable<TEntity> CreateAsyncMock<TEntity>(IEnumerable<TEntity> data)
+          where TEntity : class
+        {
+            foreach (var entity in data)
+            {
+                yield return entity;
+            }
+
+            await Task.CompletedTask;
+        }
     }
-
-    /// <summary>
-    /// This method allows you to create a mock DbSet for testing purposes.
-    /// It is particularly useful when you want to simulate the behavior of Entity Framework Core's DbSet
-    /// with custom expression handling, such as for testing LINQ queries or database operations.
-    /// The method takes an IQueryable of the entity type and returns a mocked DbSet that implements
-    /// both IAsyncEnumerable and IQueryable interfaces, allowing for asynchronous enumeration
-    /// and LINQ query capabilities.
-    /// </summary>
-    /// <typeparam name="TEntity">
-    /// The type of the entity that the DbSet will represent.
-    /// </typeparam>
-    /// <typeparam name="TExpressionVisitor">
-    /// The type of the expression visitor that will be used to process LINQ expressions.
-    /// Can be used to mock EF Core specific expression handling, such as for ILike expressions.
-    /// </typeparam>
-    public static DbSet<TEntity> BuildMockDbSet<TEntity, TExpressionVisitor>(this ICollection<TEntity> data)
-      where TEntity : class
-      where TExpressionVisitor : ExpressionVisitor, new()
-    {
-      var mock = Substitute.For<DbSet<TEntity>, IQueryable<TEntity>, IAsyncEnumerable<TEntity>>();
-      var enumerable = new TestAsyncEnumerableEfCore<TEntity, TExpressionVisitor>(data, entity => data.Remove(entity));
-
-      ConfigureAllCalls(mock, enumerable, data);
-
-      return mock;
-    }
-
-   
-
-    private static void ConfigureAllCalls<TEntity,TExpressionVisitor>(
-        this DbSet<TEntity> mock,
-        TestAsyncEnumerableEfCore<TEntity, TExpressionVisitor> enumerable,
-        ICollection<TEntity> data) 
-        where TEntity : class
-        where TExpressionVisitor : ExpressionVisitor, new()
-    {
-      mock.ConfigureAsyncEnumerableCalls(enumerable);
-      mock.ConfigureQueryableCalls(enumerable, data.AsQueryable());
-      mock.ConfigureDbSetCalls(data.AsQueryable());
-
-      if (mock is IAsyncEnumerable<TEntity> asyncEnumerable)
-      {
-        asyncEnumerable.GetAsyncEnumerator(Arg.Any<CancellationToken>()).Returns(args => enumerable.GetAsyncEnumerator());
-      }
-    }
-
-    private static void ConfigureQueryableCalls<TEntity>(
-      this IQueryable<TEntity> mock,
-      IQueryProvider queryProvider,
-      IQueryable<TEntity> data) where TEntity : class
-    {
-      mock.Provider.Returns(queryProvider);
-      mock.Expression.Returns(data?.Expression);
-      mock.ElementType.Returns(data?.ElementType);
-      mock.GetEnumerator().Returns(info => data?.GetEnumerator());
-    }
-
-    private static void ConfigureAsyncEnumerableCalls<TEntity>(
-      this DbSet<TEntity> mock,
-      IAsyncEnumerable<TEntity> enumerable) where TEntity : class
-    {
-      mock.GetAsyncEnumerator(Arg.Any<CancellationToken>()).Returns(args => enumerable.GetAsyncEnumerator());
-    }
-
-    private static void ConfigureDbSetCalls<TEntity>(this DbSet<TEntity> mock, IQueryable<TEntity> data)
-      where TEntity : class
-    {
-      mock.AsQueryable().Returns(data);
-      mock.AsAsyncEnumerable().Returns(args => CreateAsyncMock(data));
-    }
-
-    private static async IAsyncEnumerable<TEntity> CreateAsyncMock<TEntity>(IEnumerable<TEntity> data)
-      where TEntity : class
-    {
-      foreach (var entity in data)
-      {
-        yield return entity;
-      }
-
-      await Task.CompletedTask;
-    }
-  }
 }

--- a/src/MockQueryable/MockQueryable.Sample/MyService.cs
+++ b/src/MockQueryable/MockQueryable.Sample/MyService.cs
@@ -93,6 +93,8 @@ namespace MockQueryable.Sample
 
         Task<List<UserEntity>> GetAll();
 
+        Task<IEnumerable<UserEntity>> GetAllAsQueryable();
+
         IAsyncEnumerable<UserEntity> GetAllAsync();
 
         Task<int> DeleteUserAsync(Guid id);

--- a/src/MockQueryable/MockQueryable.Sample/MyServiceFakeItEasyTests.cs
+++ b/src/MockQueryable/MockQueryable.Sample/MyServiceFakeItEasyTests.cs
@@ -88,32 +88,6 @@ public class MyServiceFakeItEasyTests
     [TestCase("AnyFirstName", "AnyExistLastName", "01/20/2012", "Users with DateOfBirth more than limit")]
     [TestCase("ExistFirstName", "AnyExistLastName", "02/20/2012", "User with FirstName already exist")]
     [TestCase("AnyFirstName", "ExistLastName", "01/20/2012", "User already exist")]
-    public void DbSetCreateUserIfNotExist(string firstName, string lastName, DateTime dateOfBirth, string expectedError)
-    {
-        // arrange
-        var users = new List<UserEntity>
-        {
-            new() {LastName = "ExistLastName", DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat)},
-            new() {FirstName = "ExistFirstName"},
-            new() {DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat)},
-            new() {DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat)},
-            new() {DateOfBirth = DateTime.Parse("01/20/2012", UsCultureInfo.DateTimeFormat)},
-        };
-        var mock = users.BuildMockDbSet();
-        var userRepository = new TestDbSetRepository(mock);
-        var service = new MyService(userRepository);
-
-        // act
-        var ex = Assert.ThrowsAsync<ApplicationException>(() =>
-            service.CreateUserIfNotExist(firstName, lastName, dateOfBirth));
-
-        // assert
-        Assert.That(expectedError, Is.EqualTo(ex.Message));
-    }
-
-    [TestCase("AnyFirstName", "AnyExistLastName", "01/20/2012", "Users with DateOfBirth more than limit")]
-    [TestCase("ExistFirstName", "AnyExistLastName", "02/20/2012", "User with FirstName already exist")]
-    [TestCase("AnyFirstName", "ExistLastName", "01/20/2012", "User already exist")]
     public void DbSetCreatedFromCollectionCreateUserIfNotExist(string firstName, string lastName, DateTime dateOfBirth, string expectedError)
     {
         // arrange
@@ -136,31 +110,6 @@ public class MyServiceFakeItEasyTests
     }
 
     [TestCase("AnyFirstName", "ExistLastName", "01/20/2012")]
-    public async Task DbSetCreateUser(string firstName, string lastName, DateTime dateOfBirth)
-    {
-        // arrange
-        var userEntities = new List<UserEntity>();
-        var mock = userEntities.BuildMockDbSet();
-        A.CallTo(() => mock.AddAsync(A<UserEntity>._, A<CancellationToken>._))
-            .ReturnsLazily(call =>
-            {
-                userEntities.Add((UserEntity)call.Arguments[0]);
-                return default;
-            });
-        var userRepository = new TestDbSetRepository(mock);
-        var service = new MyService(userRepository);
-
-        // act
-        await service.CreateUserIfNotExist(firstName, lastName, dateOfBirth);
-
-        // assert
-        var entity = mock.Single();
-        Assert.That(firstName, Is.EqualTo(entity.FirstName));
-        Assert.That(lastName, Is.EqualTo(entity.LastName));
-        Assert.That(dateOfBirth, Is.EqualTo(entity.DateOfBirth));
-    }
-
-    [TestCase("AnyFirstName", "ExistLastName", "01/20/2012")]
     public async Task DbSetCreatedFromCollectionCreateUser1(string firstName, string lastName, DateTime dateOfBirth)
     {
         // arrange
@@ -179,29 +128,10 @@ public class MyServiceFakeItEasyTests
         await service.CreateUserIfNotExist(firstName, lastName, dateOfBirth);
 
         // assert
-        var entity = mock.Single();
+        var entity = await mock.SingleAsync();
         Assert.That(firstName, Is.EqualTo(entity.FirstName));
         Assert.That(lastName, Is.EqualTo(entity.LastName));
         Assert.That(dateOfBirth, Is.EqualTo(entity.DateOfBirth));
-    }
-
-    [TestCase("01/20/2012", "06/20/2018", 5)]
-    [TestCase("01/20/2012", "06/20/2012", 4)]
-    [TestCase("01/20/2012", "02/20/2012", 3)]
-    [TestCase("01/20/2010", "02/20/2011", 0)]
-    public async Task DbSetGetUserReports(DateTime from, DateTime to, int expectedCount)
-    {
-        // arrange
-        var users = TestDataHelper.CreateUserList();
-        var mock = users.BuildMockDbSet();
-        var userRepository = new TestDbSetRepository(mock);
-        var service = new MyService(userRepository);
-
-        // act
-        var result = await service.GetUserReports(from, to);
-
-        // assert
-        Assert.That(expectedCount, Is.EqualTo(result.Count));
     }
 
     [TestCase("01/20/2012", "06/20/2018", 5)]
@@ -223,8 +153,8 @@ public class MyServiceFakeItEasyTests
         Assert.That(expectedCount, Is.EqualTo(result.Count));
     }
 
-    [TestCase]
-    public async Task DbSetGetAllUserEntitiesAsync()
+    [Test]
+    public async Task DbSetCreatedFromCollectionGetAllUserEntitiesAsync()
     {
         // arrange
         var users = TestDataHelper.CreateUserList();
@@ -234,22 +164,6 @@ public class MyServiceFakeItEasyTests
 
         // act
         var result = await userRepository.GetAllAsync().ToListAsync();
-
-        // assert
-        Assert.That(users.Count, Is.EqualTo(result.Count));
-    }
-
-    [Test]
-    public async Task DbSetCreatedFromCollectionGetAllUserEntitiesAsync()
-    {
-      // arrange
-      var users = TestDataHelper.CreateUserList();
-
-      var mockDbSet = users.BuildMockDbSet();
-      var userRepository = new TestDbSetRepository(mockDbSet);
-
-      // act
-      var result = await userRepository.GetAllAsync().ToListAsync();
 
         // assert
         Assert.That(users.Count, Is.EqualTo(result.Count));
@@ -276,21 +190,6 @@ public class MyServiceFakeItEasyTests
     }
 
     [Test]
-    public async Task DbSetGetAllUserEntity()
-    {
-        //arrange
-        var users = TestDataHelper.CreateUserList();
-        var mock = users.BuildMockDbSet();
-        var userRepository = new TestDbSetRepository(mock);
-
-        //act
-        var result = await userRepository.GetAll();
-
-        //assert
-        Assert.That(users.Count, Is.EqualTo(result.Count));
-    }
-
-    [Test]
     public async Task DbSetCreatedFromCollectionGetAllUserEntity()
     {
         // arrange
@@ -305,7 +204,7 @@ public class MyServiceFakeItEasyTests
         Assert.That(users.Count, Is.EqualTo(result.Count));
     }
 
-    [TestCase]
+    [Test]
     public void GetUsersByFirstName_ExpressionVisitorMissing_ThrowsException()
     {
         // arrange
@@ -326,7 +225,7 @@ public class MyServiceFakeItEasyTests
                 "Rewrite the query to avoid client evaluation of arguments so that method can be translated to server."));
     }
 
-    [TestCase]
+    [Test]
     public async Task GetUsersByFirstName_PartOfNameCaseInsensitiveSearch_AllMatchesReturned()
     {
         // arrange
@@ -342,7 +241,7 @@ public class MyServiceFakeItEasyTests
         Assert.That(result.Count, Is.EqualTo(2));
     }
 
-    [TestCase]
+    [Test]
     public void GetUsersByLastName_ExpressionVisitorMissing_ThrowsException()
     {
         // arrange
@@ -363,7 +262,7 @@ public class MyServiceFakeItEasyTests
                 "Rewrite the query to avoid client evaluation of arguments so that method can be translated to server."));
     }
 
-    [TestCase]
+    [Test]
     public async Task GetUsersByLastName_PartOfNameCaseInsensitiveSearch_AllMatchesReturned()
     {
         // arrange
@@ -379,42 +278,56 @@ public class MyServiceFakeItEasyTests
         Assert.That(result.Count, Is.EqualTo(3));
     }
 
+    [Test]
+    public async Task GetAllUsers_AsQueryableList_AllMatchesReturned()
+    {
+        // arrange
+        var users = TestDataHelper.CreateUserList();
 
+        var mockDbSet = users.BuildMockDbSet();
+        var userRepository = new TestDbSetRepository(mockDbSet);
+
+        // act
+        var result = await userRepository.GetAllAsQueryable();
+
+        // assert
+        Assert.That(users.Count, Is.EqualTo(result.Count()));
+    }
 
     [Test]
     public async Task DbSetCreatedFromCollection_ExecuteDeleteAsync()
     {
-      // arrange
-      var userId = Guid.NewGuid();
-      var users = TestDataHelper.CreateUserList(userId);
+        // arrange
+        var userId = Guid.NewGuid();
+        var users = TestDataHelper.CreateUserList(userId);
 
-      var mockDbSet = users.BuildMockDbSet();
-      var userRepository = new TestDbSetRepository(mockDbSet);
+        var mockDbSet = users.BuildMockDbSet();
+        var userRepository = new TestDbSetRepository(mockDbSet);
 
-      // act
-      var count = await userRepository.DeleteUserAsync(userId);
+        // act
+        var count = await userRepository.DeleteUserAsync(userId);
 
-      // assert
-      Assert.That(count, Is.EqualTo(1));
-      var updatedUsers = await userRepository.GetAllAsync().ToListAsync();
-      Assert.That(updatedUsers.Any(x => x.Id == userId), Is.EqualTo(false));
+        // assert
+        Assert.That(count, Is.EqualTo(1));
+        var updatedUsers = await userRepository.GetAllAsync().ToListAsync();
+        Assert.That(updatedUsers.Any(x => x.Id == userId), Is.EqualTo(false));
     }
 
     [Test]
     public async Task DbSetCreatedFromCollectionExecuteDeleteAsync_ShouldReturnZero()
     {
-      // arrange
-      var userId = Guid.NewGuid();
-      var users = TestDataHelper.CreateUserList(userId);
+        // arrange
+        var userId = Guid.NewGuid();
+        var users = TestDataHelper.CreateUserList(userId);
 
-      var mockDbSet = users.BuildMockDbSet();
-      var userRepository = new TestDbSetRepository(mockDbSet);
+        var mockDbSet = users.BuildMockDbSet();
+        var userRepository = new TestDbSetRepository(mockDbSet);
 
-      //act
-      var count = await userRepository.DeleteUserAsync(Guid.NewGuid());
+        //act
+        var count = await userRepository.DeleteUserAsync(Guid.NewGuid());
 
-      // assert
-      Assert.That(count, Is.EqualTo(0));
+        // assert
+        Assert.That(count, Is.EqualTo(0));
     }
 
     [Test]
@@ -434,8 +347,8 @@ public class MyServiceFakeItEasyTests
         //assert
         Assert.That(count, Is.EqualTo(1));
         var user = users.Single(x => x.Id == userId);
-        Assert.That(expectedName, Is.EqualTo(user.FirstName)); 
-        Assert.That(expectedName, Is.EqualTo(user.LastName)); 
+        Assert.That(expectedName, Is.EqualTo(user.FirstName));
+        Assert.That(expectedName, Is.EqualTo(user.LastName));
     }
 
     [Test]
@@ -457,10 +370,10 @@ public class MyServiceFakeItEasyTests
         Assert.That(count, Is.EqualTo(0));
 
         var user = users.Single(x => x.Id == userId);
-        Assert.That(expectedFirstName, Is.EqualTo(user.FirstName)); 
-        Assert.That(expectedLastName, Is.EqualTo(user.LastName)); 
+        Assert.That(expectedFirstName, Is.EqualTo(user.FirstName));
+        Assert.That(expectedLastName, Is.EqualTo(user.LastName));
     }
 
 
-   
+
 }

--- a/src/MockQueryable/MockQueryable.Sample/MyServiceNSubstituteTests.cs
+++ b/src/MockQueryable/MockQueryable.Sample/MyServiceNSubstituteTests.cs
@@ -157,26 +157,6 @@ public class MyServiceNSubstituteTests
     }
 
     [TestCase("AnyFirstName", "ExistLastName", "01/20/2012")]
-    public async Task DbSetCreateUser(string firstName, string lastName, DateTime dateOfBirth)
-    {
-        //arrange
-        var userEntities = new List<UserEntity>();
-        var mock = userEntities.BuildMockDbSet();
-        mock.AddAsync(Arg.Any<UserEntity>())
-            .Returns(info => null)
-            .AndDoes(info => userEntities.Add(info.Arg<UserEntity>()));
-        var userRepository = new TestDbSetRepository(mock);
-        var service = new MyService(userRepository);
-        //act
-        await service.CreateUserIfNotExist(firstName, lastName, dateOfBirth);
-        // assert
-        var entity = mock.Single();
-        Assert.That(firstName, Is.EqualTo(entity.FirstName));
-        Assert.That(lastName, Is.EqualTo(entity.LastName));
-        Assert.That(dateOfBirth, Is.EqualTo(entity.DateOfBirth));
-    }
-
-    [TestCase("AnyFirstName", "ExistLastName", "01/20/2012")]
     public async Task DbSetCreatedFromCollectionCreateUser(string firstName, string lastName, DateTime dateOfBirth)
     {
         //arrange
@@ -200,24 +180,6 @@ public class MyServiceNSubstituteTests
     [TestCase("01/20/2012", "06/20/2012", 4)]
     [TestCase("01/20/2012", "02/20/2012", 3)]
     [TestCase("01/20/2010", "02/20/2011", 0)]
-    public async Task DbSetGetUserReports(DateTime from, DateTime to, int expectedCount)
-    {
-        //arrange
-        var users = TestDataHelper.CreateUserList();
-
-        var mock = users.BuildMockDbSet();
-        var userRepository = new TestDbSetRepository(mock);
-        var service = new MyService(userRepository);
-        //act
-        var result = await service.GetUserReports(from, to);
-        //assert
-        Assert.That(expectedCount, Is.EqualTo(result.Count));
-    }
-
-    [TestCase("01/20/2012", "06/20/2018", 5)]
-    [TestCase("01/20/2012", "06/20/2012", 4)]
-    [TestCase("01/20/2012", "02/20/2012", 3)]
-    [TestCase("01/20/2010", "02/20/2011", 0)]
     public async Task DbSetCreatedFromCollectionGetUserReports(DateTime from, DateTime to, int expectedCount)
     {
         //arrange
@@ -233,19 +195,6 @@ public class MyServiceNSubstituteTests
     }
 
     [TestCase]
-    public async Task DbSetGetAllUserEntity()
-    {
-        //arrange
-        var users = TestDataHelper.CreateUserList();
-        var mock = users.BuildMockDbSet();
-        var userRepository = new TestDbSetRepository(mock);
-        //act
-        var result = await userRepository.GetAll();
-        //assert
-        Assert.That(users.Count, Is.EqualTo(result.Count));
-    }
-
-    [TestCase]
     public async Task DbSetCreatedFromCollectionGetAllUserEntity()
     {
         //arrange
@@ -255,22 +204,6 @@ public class MyServiceNSubstituteTests
         //act
         var result = await userRepository.GetAll();
         //assert
-        Assert.That(users.Count, Is.EqualTo(result.Count));
-    }
-
-    [TestCase]
-    public async Task DbSetGetAllUserEntitiesAsync()
-    {
-        // arrange
-        var users = TestDataHelper.CreateUserList();
-
-      var mockDbSet = users.BuildMockDbSet();
-      var userRepository = new TestDbSetRepository(mockDbSet);
-
-      // act
-      var result = await userRepository.GetAllAsync().ToListAsync();
-
-        // assert
         Assert.That(users.Count, Is.EqualTo(result.Count));
     }
 
@@ -310,25 +243,7 @@ public class MyServiceNSubstituteTests
     }
 
     [TestCase]
-    public async Task DbSetGetOneUserTntityAsync()
-    {
-        // arrange
-        var users = TestDataHelper.CreateUserList();
-
-        var mockDbSet = users.BuildMockDbSet();
-        var userRepository = new TestDbSetRepository(mockDbSet);
-
-        // act
-        var result = await userRepository.GetAllAsync()
-            .Where(user => user.FirstName == "FirstName1")
-            .FirstOrDefaultAsync();
-
-        // assert
-        Assert.That(users.First(), Is.EqualTo(result));
-    }
-
-    [TestCase]
-    public async Task DbSetCreatedFromCollectionGetOneUserTntityAsync()
+    public async Task DbSetCreatedFromCollectionGetOneUserTEntityAsync()
     {
         // arrange
         var users = TestDataHelper.CreateUserList();
@@ -385,7 +300,21 @@ public class MyServiceNSubstituteTests
         Assert.That(result.Count, Is.EqualTo(2));
     }
 
+    [Test]
+    public async Task GetAllUsers_AsQueryableList_AllMatchesReturned()
+    {
+        // arrange
+        var users = TestDataHelper.CreateUserList();
 
+        var mockDbSet = users.BuildMockDbSet();
+        var userRepository = new TestDbSetRepository(mockDbSet);
+
+        // act
+        var result = await userRepository.GetAllAsQueryable();
+
+        // assert
+        Assert.That(users.Count, Is.EqualTo(result.Count()));
+    }
 
     [TestCase]
     public void GetUsersByLastName_ExpressionVisitorMissing_ThrowsException()
@@ -432,37 +361,37 @@ public class MyServiceNSubstituteTests
     [Test]
     public async Task DbSetCreatedFromCollection_ExecuteDeleteAsync()
     {
-      // arrange
-      var userId = Guid.NewGuid();
-      var users = TestDataHelper.CreateUserList(userId);
+        // arrange
+        var userId = Guid.NewGuid();
+        var users = TestDataHelper.CreateUserList(userId);
 
-      var mockDbSet = users.BuildMockDbSet();
-      var userRepository = new TestDbSetRepository(mockDbSet);
+        var mockDbSet = users.BuildMockDbSet();
+        var userRepository = new TestDbSetRepository(mockDbSet);
 
-      // act
-      var count = await userRepository.DeleteUserAsync(userId);
+        // act
+        var count = await userRepository.DeleteUserAsync(userId);
 
-      // assert
-      Assert.That(count, Is.EqualTo(1));
-      var updatedUsers = await userRepository.GetAllAsync().ToListAsync();
-      Assert.That(updatedUsers.Any(x => x.Id == userId), Is.EqualTo(false));
+        // assert
+        Assert.That(count, Is.EqualTo(1));
+        var updatedUsers = await userRepository.GetAllAsync().ToListAsync();
+        Assert.That(updatedUsers.Any(x => x.Id == userId), Is.EqualTo(false));
     }
 
     [Test]
     public async Task DbSetCreatedFromCollectionExecuteDeleteAsync_ShouldReturnZero()
     {
-      // arrange
-      var userId = Guid.NewGuid();
-      var users = TestDataHelper.CreateUserList(userId);
+        // arrange
+        var userId = Guid.NewGuid();
+        var users = TestDataHelper.CreateUserList(userId);
 
-      var mockDbSet = users.BuildMockDbSet();
-      var userRepository = new TestDbSetRepository(mockDbSet);
+        var mockDbSet = users.BuildMockDbSet();
+        var userRepository = new TestDbSetRepository(mockDbSet);
 
-      //act
-      var count = await userRepository.DeleteUserAsync(Guid.NewGuid());
+        //act
+        var count = await userRepository.DeleteUserAsync(Guid.NewGuid());
 
-      // assert
-      Assert.That(count, Is.EqualTo(0));
+        // assert
+        Assert.That(count, Is.EqualTo(0));
     }
 
     [Test]
@@ -482,8 +411,8 @@ public class MyServiceNSubstituteTests
         //assert
         Assert.That(count, Is.EqualTo(1));
         var user = users.Single(x => x.Id == userId);
-        Assert.That(expectedName, Is.EqualTo(user.FirstName)); 
-        Assert.That(expectedName, Is.EqualTo(user.LastName)); 
+        Assert.That(expectedName, Is.EqualTo(user.FirstName));
+        Assert.That(expectedName, Is.EqualTo(user.LastName));
     }
 
     [Test]
@@ -505,9 +434,9 @@ public class MyServiceNSubstituteTests
         Assert.That(count, Is.EqualTo(0));
 
         var user = users.Single(x => x.Id == userId);
-        Assert.That(expectedFirstName, Is.EqualTo(user.FirstName)); 
-        Assert.That(expectedLastName, Is.EqualTo(user.LastName)); 
+        Assert.That(expectedFirstName, Is.EqualTo(user.FirstName));
+        Assert.That(expectedLastName, Is.EqualTo(user.LastName));
     }
-    
-    
+
+
 }

--- a/src/MockQueryable/MockQueryable.Sample/TestDbSetRepository.cs
+++ b/src/MockQueryable/MockQueryable.Sample/TestDbSetRepository.cs
@@ -6,59 +6,64 @@ using System.Threading.Tasks;
 
 namespace MockQueryable.Sample
 {
-  public class TestDbSetRepository : IUserRepository
-  {
-    private readonly DbSet<UserEntity> _dbSet;
-
-    public TestDbSetRepository(DbSet<UserEntity> dbSet)
+    public class TestDbSetRepository : IUserRepository
     {
-      _dbSet = dbSet;
-    }
+        private readonly DbSet<UserEntity> _dbSet;
 
-    public IQueryable<UserEntity> GetQueryable()
-    {
-      return _dbSet;
-    }
+        public TestDbSetRepository(DbSet<UserEntity> dbSet)
+        {
+            _dbSet = dbSet;
+        }
 
-    public async Task CreateUser(UserEntity user)
-    {
-      await _dbSet.AddAsync(user);
-    }
+        public IQueryable<UserEntity> GetQueryable()
+        {
+            return _dbSet;
+        }
 
-    public async Task<List<UserEntity>> GetAll()
-    {
-      return await _dbSet.ToListAsync();
-    }
+        public async Task CreateUser(UserEntity user)
+        {
+            await _dbSet.AddAsync(user);
+        }
 
-    public IAsyncEnumerable<UserEntity> GetAllAsync()
-    {
-      return _dbSet.AsAsyncEnumerable();
-    }
+        public async Task<List<UserEntity>> GetAll()
+        {
+            return await _dbSet.ToListAsync();
+        }
 
-    public async Task<IEnumerable<UserEntity>> GetUsersByFirstName(string firstName)
-    {
-      return await _dbSet
-        .Where(x => EF.Functions.Like(x.FirstName, $"%{firstName}%"))
-        .ToListAsync();
-    }
+        public async Task<IEnumerable<UserEntity>> GetAllAsQueryable()
+        {
+            return await _dbSet.AsQueryable().ToListAsync();
+        }
 
-    public async Task<IEnumerable<UserEntity>> GetUsersByLastName(string firstName)
-    {
-        return await _dbSet
-            .Where(x => EF.Functions.ILike(x.LastName, $"%{firstName}%"))
-            .ToListAsync();
-    }
+        public IAsyncEnumerable<UserEntity> GetAllAsync()
+        {
+            return _dbSet.AsAsyncEnumerable();
+        }
 
-    public async Task<int> DeleteUserAsync(Guid id)
-    {
-        return await _dbSet.Where(x => x.Id == id)
-            .ExecuteDeleteAsync();
-    }
+        public async Task<IEnumerable<UserEntity>> GetUsersByFirstName(string firstName)
+        {
+            return await _dbSet
+              .Where(x => EF.Functions.Like(x.FirstName, $"%{firstName}%"))
+              .ToListAsync();
+        }
 
-    public async Task<int> UpdateFirstAndLastNameByIdAsync(Guid id, string firstName)
-    {
-        return await _dbSet.Where(x => x.Id == id)
-            .ExecuteUpdateAsync(opt => opt.SetProperty(x => x.FirstName, firstName).SetProperty(x => x.LastName, firstName));
+        public async Task<IEnumerable<UserEntity>> GetUsersByLastName(string firstName)
+        {
+            return await _dbSet
+                .Where(x => EF.Functions.ILike(x.LastName, $"%{firstName}%"))
+                .ToListAsync();
+        }
+
+        public async Task<int> DeleteUserAsync(Guid id)
+        {
+            return await _dbSet.Where(x => x.Id == id)
+                .ExecuteDeleteAsync();
+        }
+
+        public async Task<int> UpdateFirstAndLastNameByIdAsync(Guid id, string firstName)
+        {
+            return await _dbSet.Where(x => x.Id == id)
+                .ExecuteUpdateAsync(opt => opt.SetProperty(x => x.FirstName, firstName).SetProperty(x => x.LastName, firstName));
+        }
     }
-  }
 }


### PR DESCRIPTION
# PR Details

- Fix `.AsQueryable` calls to the test data set by returning the mocked data set instead of the actual data set for the faked `AsQueryable` call
- Deleted duplicated tests (identical code)

## Description

Following call:
`A.CallTo(() => mock.AsQueryable()).Returns(data.AsQueryable());`

...was replaced with:
`A.CallTo(() => mock.AsQueryable()).Returns(mock);`

This fixes the issue, as the mock will relay any further calls to the test query provider. So any further calls work the same as if `.AsQueryable()` was not called.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#88 

## How Has This Been Tested

- Created new unit tests for all three variants to ensure that `AsQueryable()` calls work for all mocking frameworks.
- Ensured all new unit tests passed and that existing tests remained unaffected.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
