### PR TITLE
Move EF Dependency to v8

### DIFF
--- a/src/MockQueryable/MockQueryable.EntityFrameworkCore/MockQueryable.EntityFrameworkCore.csproj
+++ b/src/MockQueryable/MockQueryable.EntityFrameworkCore/MockQueryable.EntityFrameworkCore.csproj
@@ -48,7 +48,8 @@
 		</None>
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.7" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.20" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.20" />
 	</ItemGroup>
 
   <ItemGroup>

--- a/src/MockQueryable/MockQueryable.EntityFrameworkCore/TestQueryProviderEfCore.cs
+++ b/src/MockQueryable/MockQueryable.EntityFrameworkCore/TestQueryProviderEfCore.cs
@@ -55,19 +55,19 @@ public class TestAsyncEnumerableEfCore<T, TExpressionVisitor> : TestQueryProvide
         // Intercept ExecuteDelete and ExecuteUpdate calls
         if (expression is MethodCallExpression
             {
-                Method.Name: nameof(EntityFrameworkQueryableExtensions.ExecuteUpdate)
-                or nameof(EntityFrameworkQueryableExtensions.ExecuteDelete)
+                Method.Name: nameof(RelationalQueryableExtensions.ExecuteUpdate)
+                or nameof(RelationalQueryableExtensions.ExecuteDelete)
             } methodCall &&
             typeof(TResult) == typeof(int))
         {
             var affectedItems = base.Execute<IEnumerable<T>>(Expression).ToList();
 
-            if (methodCall.Method.Name == nameof(EntityFrameworkQueryableExtensions.ExecuteUpdate))
+            if (methodCall.Method.Name == nameof(RelationalQueryableExtensions.ExecuteUpdate))
             {
                 ApplyUpdateChangesToDbSet(affectedItems, methodCall);
             }
 
-            if (methodCall.Method.Name == nameof(EntityFrameworkQueryableExtensions.ExecuteDelete))
+            if (methodCall.Method.Name == nameof(RelationalQueryableExtensions.ExecuteDelete))
             {
                 foreach (var item in affectedItems)
                 {


### PR DESCRIPTION
# PR Details

As the Execute methods only got moved to EntityFrameworkQueryableExtensions in V9 have to use Microsoft.EntityFrameworkCore.Relational package

See change on EF here
https://github.com/dotnet/efcore/commit/96e848ebd544910ae6ea02e472304a6201b888a5

## Related Issue

https://github.com/romantitov/MockQueryable/issues/89

## How Has This Been Tested

All existing tests are passing

## Checklist

- [ y] My code follows the code style of this project.
- [n ] I have added tests to cover my changes.
- [y ] All new and existing tests passed.
